### PR TITLE
Update guessing-game.md（leave offの訳について）

### DIFF
--- a/1.6/ja/book/guessing-game.md
+++ b/1.6/ja/book/guessing-game.md
@@ -387,7 +387,7 @@ Rustの主要な売りの1つが参照をいかに安全に簡単に使えるか
 
 <!-- If we leave off calling these two methods, our program will compile, but -->
 <!-- we’ll get a warning: -->
-この2つのメソッドを呼び出したままにしておくと、プログラムはコンパイルしますが、警告が出ます。
+この2つのメソッドを呼び出さないままにしておくと、プログラムはコンパイルしますが、警告が出ます。
 
 ```bash
 $ cargo build


### PR DESCRIPTION
[原文](https://doc.rust-lang.org/book/guessing-game.html) をみると `leave off` とあるので、「呼び出すのをやめる」という意味かと思います。 http://ejje.weblio.jp/content/leave+off

実際に `cargo run` したときの挙動としても、 `.expect()` の呼び出しがあると警告なし、呼び出しがないと警告が出る、となります。

<img width="826" alt="2016-03-14 4 11 11" src="https://cloud.githubusercontent.com/assets/10515/13730734/dced5da8-e99a-11e5-87cd-c57b8feb67db.png">
<img width="808" alt="2016-03-14 4 11 29" src="https://cloud.githubusercontent.com/assets/10515/13730735/e4212816-e99a-11e5-9476-2c3aa5850b70.png">
