### PR TITLE
Update guessing-game.md（anything of type `Foo` can be eitherの訳について）

### DIFF
--- a/1.6/ja/book/guessing-game.md
+++ b/1.6/ja/book/guessing-game.md
@@ -804,7 +804,7 @@ enum Foo {
 <!-- With this definition, anything of type `Foo` can be either a -->
 <!-- `Foo::Bar` or a `Foo::Baz`. We use the `::` to indicate the -->
 <!-- namespace for a particular `enum` variant. -->
-この定義だと、 `Foo` のに属するものは `Foo::Bar` あるいは `Foo::Baz` です。
+この定義だと、 `Foo` 型のものは `Foo::Bar` あるいは `Foo::Baz` のいずれかです。
 `::` を使って `enum` のバリアントの名前空間を指示します。
 
 <!-- The [`Ordering`][ordering] `enum` has three possible variants: `Less`, `Equal`, -->


### PR DESCRIPTION
"`Foo` のに属するものは" の "のに" を直すついでに、文章自体を少し手直ししました。

"anything of type Foo can be either a Foo::Bar or a Foo::Baz." の訳がわからなかったのですが、機械翻訳してみてもあながち間違いではなさそうなので、その訳文を踏襲しました。

<img width="1280" alt="2016-03-15 3 24 31" src="https://cloud.githubusercontent.com/assets/10515/13755266/bba16d42-ea5d-11e5-8716-bbb589939c37.png">
