### PR TITLE
[FIX] 4.19 Traits

### DIFF
--- a/1.6/ja/book/traits.md
+++ b/1.6/ja/book/traits.md
@@ -318,7 +318,7 @@ not, because neither the trait nor the type are in our code. -->
 <!-- One last thing about traits: generic functions with a trait bound use
 ‘monomorphization’ (mono: one, morph: form), so they are statically dispatched.
 What’s that mean? Check out the chapter on [trait objects][to] for more details. -->
-トレイトに関して最後に1つ。トレイト境界が設定されたジェネリック関数は「モノモーフィゼーション」(monomorphization)(mono:単一の、morph:様相)されるため、静的ディスパッチが行われます。一体どういう意味でしょうか？詳細については、 [トレイトオブジェクト][to] の章をチェックしてください。
+トレイトに関して最後に1つ。トレイト境界が設定されたジェネリック関数は「単相化」(monomorphization)(mono:単一の、morph:様相)されるため、静的ディスパッチが行われます。一体どういう意味でしょうか？詳細については、 [トレイトオブジェクト][to] の章をチェックしてください。
 
 [to]: trait-objects.html
 

--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -111,6 +111,7 @@
 | match                          | マッチ
 | memory                         | メモリ
 | method                         | メソッド
+| monomorphization               | 単相化
 | move                           | ムーブ
 | mutability                     | ミュータビリティ
 | mutable                        | ミュータブル


### PR DESCRIPTION
#88 において「モノモーフィゼーション」の訳が「単相化」に決定した事への対応です。
