### PR TITLE
4.25. Crates and Modules

### DIFF
--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -117,7 +117,7 @@ with double-colon (`::`) notation: our four nested modules are
 parent module, the names don’t conflict: `english::greetings` and
 `japanese::greetings` are distinct, even though their names are both
 `greetings`. -->
-与えられた `mod` 内で、サブ `mod` を定義することができます。サブモジュールは2重コロン( `::` )記法で参照できます。先程定義した4つのネストされたモジュールは `english::greetings` 、 `english::farewells` 、 `japanese::greetings` 、そして `japanese::farewells` です。これらサブモジュールは親モジュール配下の名前空間であるため、名前は衝突しません。つまり `english::greetings` と `japanese::greetings` は例え両名が `greetings` であったとしても、明確に区別されます。
+与えられた `mod` 内で、サブ `mod` を定義することができます。サブモジュールは2重コロン( `::` )記法で参照できます。先程定義した4つのネストされたモジュールは `english::greetings` 、 `english::farewells` 、 `japanese::greetings` 、そして `japanese::farewells` です。これらサブモジュールは親モジュール配下の名前空間であるため、名前は競合しません。つまり `english::greetings` と `japanese::greetings` は例え両名が `greetings` であったとしても、明確に区別されます。
 
 <!-- Because this crate does not have a `main()` function, and is called `lib.rs`,
 Cargo will build this crate as a library: -->
@@ -422,8 +422,9 @@ refer to them with shorter names. Let’s talk about `use`. -->
 <!-- # Importing Modules with `use` -->
 # `use` でモジュールをインポートする
 
-Rust has a `use` keyword, which allows us to import names into our local scope.
-Let’s change our `src/main.rs` to look like this:
+<!-- Rust has a `use` keyword, which allows us to import names into our local scope.
+Let’s change our `src/main.rs` to look like this: -->
+Rustには `use` キーワードがあり、ローカルスコープの中に名前をインポートできます。 `src/main.rs` を以下のように変えてみましょう。
 
 ```rust,ignore
 extern crate phrases;
@@ -437,10 +438,11 @@ fn main() {
 }
 ```
 
-The two `use` lines import each module into the local scope, so we can refer to
+<!-- The two `use` lines import each module into the local scope, so we can refer to
 the functions by a much shorter name. By convention, when importing functions, it’s
 considered best practice to import the module, rather than the function directly. In
-other words, you _can_ do this:
+other words, you _can_ do this: -->
+2つの `use` の行はローカルスコープの中に各モジュールをインポートしているため、とても短い名前で関数を参照できます。慣習では、関数をインポートするとき、関数を直接するよりもモジュール単位でするのがベストプラクティスだと考えられています。言い換えれば、こうすることも _できる_ わけです。
 
 ```rust,ignore
 extern crate phrases;
@@ -454,11 +456,12 @@ fn main() {
 }
 ```
 
-But it is not idiomatic. This is significantly more likely to introduce a
+<!-- But it is not idiomatic. This is significantly more likely to introduce a
 naming conflict. In our short program, it’s not a big deal, but as it grows, it
 becomes a problem. If we have conflicting names, Rust will give a compilation
 error. For example, if we made the `japanese` functions public, and tried to do
-this:
+this: -->
+しかしこれは慣用的ではありません。これは名前の競合を引き起こす可能性が非常に高いのです。この短いプログラムだと大したことではありませんが、大きくなるにつれ問題になります。名前が競合すると、Rustはコンパイルエラーになります。例えば、 `japanese` 関数をパブリックにして、以下を試してみます。
 
 ```rust,ignore
 extern crate phrases;
@@ -472,7 +475,8 @@ fn main() {
 }
 ```
 
-Rust will give us a compile-time error:
+<!-- Rust will give us a compile-time error: -->
+Rustはコンパイル時エラーになります。
 
 ```text
    Compiling phrases v0.0.1 (file:///home/you/projects/phrases)
@@ -483,21 +487,24 @@ error: aborting due to previous error
 Could not compile `phrases`.
 ```
 
-If we’re importing multiple names from the same module, we don’t have to type it out
-twice. Instead of this:
+<!-- If we’re importing multiple names from the same module, we don’t have to type it out
+twice. Instead of this: -->
+同じモジュールから複数の名前をインポートする場合、二度同じ文字を打つ必要はありません。以下の代わりに、
 
 ```rust,ignore
 use phrases::english::greetings;
 use phrases::english::farewells;
 ```
 
-We can use this shortcut:
+<!-- We can use this shortcut: -->
+このショートカットが使えます。
 
 ```rust,ignore
 use phrases::english::{greetings, farewells};
 ```
 
 ## Re-exporting with `pub use`
+## `pub use` による再エクスポート
 
 You don’t just use `use` to shorten identifiers. You can also use it inside of your crate
 to re-export a function inside another module. This allows you to present an external

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -1,28 +1,33 @@
 % クレートとモジュール
 <!-- % Crates and Modules -->
 
-When a project starts getting large, it’s considered good software
+<!-- When a project starts getting large, it’s considered good software
 engineering practice to split it up into a bunch of smaller pieces, and then
 fit them together. It’s also important to have a well-defined interface, so
 that some of your functionality is private, and some is public. To facilitate
-these kinds of things, Rust has a module system.
+these kinds of things, Rust has a module system. -->
+プロジェクトが大きくなり始めた際に、コードを幾つかのまとまりに分割しそれらでプロジェクトを組み立てるのはソフトウェア工学における優れた慣例だと考えられています。機能の一部をプライベートとし、かつ幾つかをパブリックとできるように、はっきりと定義されたインターフェースも重要となります。こういった事柄を容易にするため、Rustはモジュールシステムを有しています。
 
-# Basic terminology: Crates and Modules
+<!-- # Basic terminology: Crates and Modules -->
+# 基本的な専門用語: クレートとモジュール
 
-Rust has two distinct terms that relate to the module system: ‘crate’ and
+<!-- Rust has two distinct terms that relate to the module system: ‘crate’ and
 ‘module’. A crate is synonymous with a ‘library’ or ‘package’ in other
 languages. Hence “Cargo” as the name of Rust’s package management tool: you
 ship your crates to others with Cargo. Crates can produce an executable or a
-library, depending on the project.
+library, depending on the project. -->
+Rustはモジュールシステムに関連して、「クレート」(crate)と「モジュール」(module)という2つの用語を明確に分けています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。(訳注: crateとは枠箱のことであり、cargoは船荷を指します)Cargoを使ってあなたのクレートを船で出荷し他のユーザに公開するわけです。クレートは実行ファイルかライブラリをプロジェクトに応じて作成できます。
 
-Each crate has an implicit *root module* that contains the code for that crate.
+<!-- Each crate has an implicit *root module* that contains the code for that crate.
 You can then define a tree of sub-modules under that root module. Modules allow
-you to partition your code within the crate itself.
+you to partition your code within the crate itself. -->
+各クレートは自身のコードが入っている *ルートモジュール* (root module)を暗黙的に持っています。この時ルートモジュール下にはサブモジュールの木が定義できます。モジュールによりクレート内でコードを分割できます。
 
-As an example, let’s make a *phrases* crate, which will give us various phrases
+<!-- As an example, let’s make a *phrases* crate, which will give us various phrases
 in different languages. To keep things simple, we’ll stick to ‘greetings’ and
 ‘farewells’ as two kinds of phrases, and use English and Japanese (日本語) as
-two languages for those phrases to be in. We’ll use this module layout:
+two languages for those phrases to be in. We’ll use this module layout: -->
+例として、 *phrases* クレートを作ってみます。これには異なる言語で幾つかのフレーズを入れます。問題の単純さを保つために、2種類のフレーズとして「greetings」と「farewells」に固定し、これらフレーズを表すための2つの言語として英語と日本語を使うことにします。
 
 ```text
                                     +-----------+
@@ -44,19 +49,22 @@ two languages for those phrases to be in. We’ll use this module layout:
                                     +-----------+
 ```
 
-In this example, `phrases` is the name of our crate. All of the rest are
+<!-- In this example, `phrases` is the name of our crate. All of the rest are
 modules.  You can see that they form a tree, branching out from the crate
-*root*, which is the root of the tree: `phrases` itself.
+*root*, which is the root of the tree: `phrases` itself. -->
+この例において、 `phrases` はクレートの名前です。それ以外の全てはモジュールです。それらが木の形をしており、クレートの *根* から枝分かれしていることが分かります。そして木の根は `phrases` それ自身です。
 
-Now that we have a plan, let’s define these modules in code. To start,
-generate a new crate with Cargo:
+<!-- Now that we have a plan, let’s define these modules in code. To start,
+generate a new crate with Cargo: -->
+ここまでで計画は立ちましたから、これらモジュールをコードで定義しましょう。始めるために、Cargoで新しいクレートを生成します。
 
 ```bash
 $ cargo new phrases
 $ cd phrases
 ```
 
-If you remember, this generates a simple project for us:
+<!-- If you remember, this generates a simple project for us: -->
+このコマンドを覚えていれば、Cargoがシンプルなプロジェクトを生成してくれます。
 
 ```bash
 $ tree .
@@ -68,10 +76,12 @@ $ tree .
 1 directory, 2 files
 ```
 
-`src/lib.rs` is our crate root, corresponding to the `phrases` in our diagram
-above.
+<!-- `src/lib.rs` is our crate root, corresponding to the `phrases` in our diagram
+above. -->
+`src/lib.rs` はクレートの根であり、先程の図における `phrases` に相当します。
 
-# Defining Modules
+<!-- # Defining Modules -->
+# モジュールを定義する
 
 To define each of our modules, we use the `mod` keyword. Let’s make our
 `src/lib.rs` look like this:

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -16,7 +16,7 @@ these kinds of things, Rust has a module system. -->
 languages. Hence “Cargo” as the name of Rust’s package management tool: you
 ship your crates to others with Cargo. Crates can produce an executable or a
 library, depending on the project. -->
-Rustはモジュールシステムに関連して、「クレート」(crate)と「モジュール」(module)という2つの用語を明確に分けています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。(訳注: crateとは枠箱のことであり、cargoは船荷を指します)Cargoを使ってあなたのクレートを船で出荷し他のユーザに公開するわけです。クレートは実行ファイルかライブラリをプロジェクトに応じて作成できます。
+Rustはモジュールシステムに関連して、「クレート」(crate)と「モジュール」(module)という2つの用語を明確に分けています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってあなたのクレートを船で出荷し他のユーザに公開するわけです。クレートは実行ファイルかライブラリをプロジェクトに応じて作成できます。
 
 <!-- Each crate has an implicit *root module* that contains the code for that crate.
 You can then define a tree of sub-modules under that root module. Modules allow
@@ -136,32 +136,39 @@ crate from another crate, let’s break it up into multiple files. -->
 <!-- # Multiple file crates -->
 # 複数のファイルによるクレート
 
-If each crate were just one file, these files would get very large. It’s often
+<!-- If each crate were just one file, these files would get very large. It’s often
 easier to split up crates into multiple files, and Rust supports this in two
-ways.
+ways. -->
+各クレートがただ1つのファイルからなるのであれば、これらファイルは非常に大きくなってしまうでしょう。クレートを複数のファイルに分けた方が楽になるため、Rustは2つの方法でこれをサポートしています。
 
-Instead of declaring a module like this:
+<!-- Instead of declaring a module like this: -->
+以下のようなモジュールを宣言する代わりに、
 
 ```rust,ignore
 mod english {
-    // contents of our module go here
+# //    // contents of our module go here
+    // モジュールの内容はここに
 }
 ```
 
-We can instead declare our module like this:
+<!-- We can instead declare our module like this: -->
+このようなモジュールが宣言できます。
 
 ```rust,ignore
 mod english;
 ```
 
-If we do that, Rust will expect to find either a `english.rs` file, or a
-`english/mod.rs` file with the contents of our module.
+<!-- If we do that, Rust will expect to find either a `english.rs` file, or a
+`english/mod.rs` file with the contents of our module. -->
+こうすれば、Rustは `english.rs` ファイルか、 `english/mod.rs` ファイルのどちらかにモジュールの内容があるだろうと予期します。
 
-Note that in these files, you don’t need to re-declare the module: that’s
-already been done with the initial `mod` declaration.
+<!-- Note that in these files, you don’t need to re-declare the module: that’s
+already been done with the initial `mod` declaration. -->
+それらのファイルの中でモジュールの再宣言を行う必要がないことに気をつけて下さい。先の `mod` 宣言にてそれは済んでいます。
 
-Using these two techniques, we can break up our crate into two directories and
-seven files:
+<!-- Using these two techniques, we can break up our crate into two directories and
+seven files: -->
+これら2つのテクニックを用いて、クレートを2つのディレクトリと7つのファイルに分解できます。
 
 ```bash
 $ tree .
@@ -187,34 +194,39 @@ $ tree .
         └── native
 ```
 
-`src/lib.rs` is our crate root, and looks like this:
+<!-- `src/lib.rs` is our crate root, and looks like this: -->
+`src/lib.rs` はクレートの根で、以下のようになっています。
 
 ```rust,ignore
 mod english;
 mod japanese;
 ```
 
-These two declarations tell Rust to look for either `src/english.rs` and
+<!-- These two declarations tell Rust to look for either `src/english.rs` and
 `src/japanese.rs`, or `src/english/mod.rs` and `src/japanese/mod.rs`, depending
 on our preference. In this case, because our modules have sub-modules, we’ve
 chosen the second. Both `src/english/mod.rs` and `src/japanese/mod.rs` look
-like this:
+like this: -->
+これら2つの宣言はRustへ書き手の好みに合わせて `src/english.rs` と `src/japanese.rs` 、または `src/english/mod.rs` と `src/japanese/mod.rs` のどちらかを見よと伝えています。今回の場合、サブモジュールがあるため、私たちは後者を選択しました。 `src/english/mod.rs` と `src/japanese/mod.rs` は両方とも以下のようになっています。
 
 ```rust,ignore
 mod greetings;
 mod farewells;
 ```
 
-Again, these declarations tell Rust to look for either
+<!-- Again, these declarations tell Rust to look for either
 `src/english/greetings.rs` and `src/japanese/greetings.rs` or
 `src/english/farewells/mod.rs` and `src/japanese/farewells/mod.rs`. Because
 these sub-modules don’t have their own sub-modules, we’ve chosen to make them
-`src/english/greetings.rs` and `src/japanese/farewells.rs`. Whew!
+`src/english/greetings.rs` and `src/japanese/farewells.rs`. Whew! -->
+繰り返すと、これら宣言はRustへ `src/english/greetings.rs` と `src/japanese/greetings.rs` 、または `src/english/farewells/mod.rs` と `src/japanese/farewells/mod.rs` のどちらかを見よと伝えています。これらサブモジュールは自身配下のサブモジュールを持たないため、私たちは `src/english/greetings.rs` と `src/japanese/farewells.rs` を選びました。ヒュー！
 
-The contents of `src/english/greetings.rs` and `src/japanese/farewells.rs` are
-both empty at the moment. Let’s add some functions.
+<!-- The contents of `src/english/greetings.rs` and `src/japanese/farewells.rs` are
+both empty at the moment. Let’s add some functions. -->
+`src/english/greetings.rs` と `src/japanese/farewells.rs` の中身は現在両方とも空です。幾つか関数を追加しましょう。
 
-Put this in `src/english/greetings.rs`:
+<!-- Put this in `src/english/greetings.rs`: -->
+`src/english/greetings.rs` に以下を入力します。
 
 ```rust
 fn hello() -> String {
@@ -222,7 +234,8 @@ fn hello() -> String {
 }
 ```
 
-Put this in `src/english/farewells.rs`:
+<!-- Put this in `src/english/farewells.rs`: -->
+`src/english/farewells.rs` には以下を入力します。
 
 ```rust
 fn goodbye() -> String {
@@ -230,7 +243,8 @@ fn goodbye() -> String {
 }
 ```
 
-Put this in `src/japanese/greetings.rs`:
+<!-- Put this in `src/japanese/greetings.rs`: -->
+`src/japanese/greetings.rs` には以下を入力します。
 
 ```rust
 fn hello() -> String {
@@ -238,11 +252,13 @@ fn hello() -> String {
 }
 ```
 
-Of course, you can copy and paste this from this web page, or just type
+<!-- Of course, you can copy and paste this from this web page, or just type
 something else. It’s not important that you actually put ‘konnichiwa’ to learn
-about the module system.
+about the module system. -->
+勿論、このwebページからコピー&ペーストしたり、単に他の何かをタイプしても構いません。あなたが実際にモジュールシステムについて学ぶために「konnichiwa」と入力するのは重要なことではありません。
 
-Put this in `src/japanese/farewells.rs`:
+<!-- Put this in `src/japanese/farewells.rs`: -->
+`src/japanese/farewells.rs` には以下を入力します。
 
 ```rust
 fn goodbye() -> String {
@@ -250,12 +266,15 @@ fn goodbye() -> String {
 }
 ```
 
-(This is ‘Sayōnara’, if you’re curious.)
+<!-- (This is ‘Sayōnara’, if you’re curious.) -->
+（英語だと「Sayōnara」と表記するようです、御参考まで。）
 
-Now that we have some functionality in our crate, let’s try to use it from
-another crate.
+<!-- Now that we have some functionality in our crate, let’s try to use it from
+another crate. -->
+ここまででクレートは幾つかの機能を得ました、それでは他のクレートから使ってみましょう。
 
-# Importing External Crates
+<!-- # Importing External Crates -->
+# 外部クレートのインポート
 
 We have a library crate. Let’s make an executable crate that imports and uses
 our library.

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -16,7 +16,7 @@ these kinds of things, Rust has a module system. -->
 languages. Hence “Cargo” as the name of Rust’s package management tool: you
 ship your crates to others with Cargo. Crates can produce an executable or a
 library, depending on the project. -->
-Rustはモジュールシステムに関連して「クレート」(crate)と「モジュール」(module)という2つの用語を明確に区別しています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってクレートを出荷し他のユーザに公開するわけです。クレートは実行形式かライブラリをプロジェクトに応じて作成できます。
+Rustはモジュールシステムに関連する「クレート」(crate)と「モジュール」(module)という2つの用語を明確に区別しています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってクレートを出荷し他のユーザに公開するわけです。クレートは実行形式かライブラリをプロジェクトに応じて作成できます。
 
 <!-- Each crate has an implicit *root module* that contains the code for that crate.
 You can then define a tree of sub-modules under that root module. Modules allow
@@ -64,7 +64,7 @@ $ cd phrases
 ```
 
 <!-- If you remember, this generates a simple project for us: -->
-これを覚えておけば、Cargoが単純なプロジェクトを生成してくれます。
+これを覚えておけばCargoが単純なプロジェクトを生成してくれます。
 
 ```bash
 $ tree .

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -16,7 +16,7 @@ these kinds of things, Rust has a module system. -->
 languages. Hence “Cargo” as the name of Rust’s package management tool: you
 ship your crates to others with Cargo. Crates can produce an executable or a
 library, depending on the project. -->
-Rustはモジュールシステムに関連して、「クレート」(crate)と「モジュール」(module)という2つの用語を明確に分けています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってあなたのクレートを船で出荷し他のユーザに公開するわけです。クレートは実行ファイルかライブラリをプロジェクトに応じて作成できます。
+Rustはモジュールシステムに関連して、「クレート」(crate)と「モジュール」(module)という2つの用語を明確に分けています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってあなたのクレートを船で出荷し他のユーザに公開するわけです。クレートは実行形式かライブラリをプロジェクトに応じて作成できます。
 
 <!-- Each crate has an implicit *root module* that contains the code for that crate.
 You can then define a tree of sub-modules under that root module. Modules allow
@@ -78,7 +78,7 @@ $ tree .
 
 <!-- `src/lib.rs` is our crate root, corresponding to the `phrases` in our diagram
 above. -->
-`src/lib.rs` はクレートの根であり、先程の図における `phrases` に相当します。
+`src/lib.rs` はクレートのルートであり、先程の図における `phrases` に相当します。
 
 <!-- # Defining Modules -->
 # モジュールを定義する
@@ -195,7 +195,7 @@ $ tree .
 ```
 
 <!-- `src/lib.rs` is our crate root, and looks like this: -->
-`src/lib.rs` はクレートの根で、以下のようになっています。
+`src/lib.rs` はクレートのルートで、以下のようになっています。
 
 ```rust,ignore
 mod english;
@@ -276,10 +276,12 @@ another crate. -->
 <!-- # Importing External Crates -->
 # 外部クレートのインポート
 
-We have a library crate. Let’s make an executable crate that imports and uses
-our library.
+<!-- We have a library crate. Let’s make an executable crate that imports and uses
+our library. -->
+前節でライブラリクレートができました。インポートしこのライブラリを用いた実行形式クレートを作成しましょう。
 
-Make a `src/main.rs` and put this in it (it won’t quite compile yet):
+<!-- Make a `src/main.rs` and put this in it (it won’t quite compile yet): -->
+`src/main.rs` を作成し配置します。（これはまだ全くコンパイルされていません）
 
 ```rust,ignore
 extern crate phrases;
@@ -293,24 +295,28 @@ fn main() {
 }
 ```
 
-The `extern crate` declaration tells Rust that we need to compile and link to
+<!-- The `extern crate` declaration tells Rust that we need to compile and link to
 the `phrases` crate. We can then use `phrases`’ modules in this one. As we
 mentioned earlier, you can use double colons to refer to sub-modules and the
-functions inside of them.
+functions inside of them. -->
+`extern crate` 宣言はRustにコンパイルして `phrases` クレートをリンクせよと伝えます。するとこのクレート内で `phrases` モジュールが使えます。早期に言及していたように、2重コロンでサブモジュールとその中の関数を参照できます。
 
-(Note: when importing a crate that has dashes in its name "like-this", which is
+<!-- (Note: when importing a crate that has dashes in its name "like-this", which is
 not a valid Rust identifier, it will be converted by changing the dashes to
-underscores, so you would write `extern crate like_this;`.)
+underscores, so you would write `extern crate like_this;`.) -->
+（注意: Rustの識別子として適切でない「like-this」のような、名前の中にダッシュが入ったクレートをインポートする場合、ダッシュがアンダースコアへ変換されるため `extern crate like_this;` と記述します。）
 
-Also, Cargo assumes that `src/main.rs` is the crate root of a binary crate,
+<!-- Also, Cargo assumes that `src/main.rs` is the crate root of a binary crate,
 rather than a library crate. Our package now has two crates: `src/lib.rs` and
 `src/main.rs`. This pattern is quite common for executable crates: most
 functionality is in a library crate, and the executable crate uses that
 library. This way, other programs can also use the library crate, and it’s also
-a nice separation of concerns.
+a nice separation of concerns. -->
+また、Cargoは `src/main.rs` がライブラリクレートではなくバイナリクレートのルートであることを仮定します。パッケージは今2つのクレートを持っています。 `src/lib.rs` と `src/main.rs` です。ほとんどの機能をライブラリクレート内に置き、実行形式クレートから使用するのは、実行形式クレートとしては非常にありふれたパターンです。この方法で、他のプログラムもライブラリクレートを使うことできますし、素敵な関心の分離(separation of concerns)でもあります。
 
-This doesn’t quite work yet, though. We get four errors that look similar to
-this:
+<!-- This doesn’t quite work yet, though. We get four errors that look similar to
+this: -->
+けれどこのままでは動作しません。これに似た4つのエラーが発生します。
 
 ```bash
 $ cargo build
@@ -326,10 +332,12 @@ note: in expansion of format_args!
 phrases/src/main.rs:4:5: 4:76 note: expansion site
 ```
 
-By default, everything is private in Rust. Let’s talk about this in some more
-depth.
+<!-- By default, everything is private in Rust. Let’s talk about this in some more
+depth. -->
+デフォルトでは、Rustにおける全てはプライベートです。それではこれに関してより詳しく説明しましょう。
 
-# Exporting a Public Interface
+<!-- # Exporting a Public Interface -->
+# パブリックなインターフェースのエクスポート
 
 Rust allows you to precisely control which aspects of your interface are
 public, and so private is the default. To make things public, you use the `pub`

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -506,11 +506,13 @@ use phrases::english::{greetings, farewells};
 <!-- ## Re-exporting with `pub use` -->
 ## `pub use` による再エクスポート
 
-You don’t just use `use` to shorten identifiers. You can also use it inside of your crate
+<!-- You don’t just use `use` to shorten identifiers. You can also use it inside of your crate
 to re-export a function inside another module. This allows you to present an external
-interface that may not directly map to your internal code organization.
+interface that may not directly map to your internal code organization. -->
+`use` は識別子を短くするためだけに用いるのではありません。他のモジュール内の関数を再エクスポートするためにクレートの中で使うこともできます。これにより内部のコード構成に直接対応しない外部インターフェースを提供できます。
 
-Let’s look at an example. Modify your `src/main.rs` to read like this:
+<!-- Let’s look at an example. Modify your `src/main.rs` to read like this: -->
+例を見てみましょう。 `src/main.rs` を以下のように変更します。
 
 ```rust,ignore
 extern crate phrases;
@@ -527,14 +529,16 @@ fn main() {
 }
 ```
 
-Then, modify your `src/lib.rs` to make the `japanese` mod public:
+<!-- Then, modify your `src/lib.rs` to make the `japanese` mod public: -->
+そして、 `src/lib.rs` の `japanese` モジュールをパブリックに変更します。
 
 ```rust,ignore
 pub mod english;
 pub mod japanese;
 ```
 
-Next, make the two functions public, first in `src/japanese/greetings.rs`:
+<!-- Next, make the two functions public, first in `src/japanese/greetings.rs`: -->
+続いて、2つの関数をパブリックにします。始めに `src/japanese/greetings.rs` を、
 
 ```rust,ignore
 pub fn hello() -> String {
@@ -542,7 +546,8 @@ pub fn hello() -> String {
 }
 ```
 
-And then in `src/japanese/farewells.rs`:
+<!-- And then in `src/japanese/farewells.rs`: -->
+そして `src/japanese/farewells.rs` を、
 
 ```rust,ignore
 pub fn goodbye() -> String {
@@ -550,7 +555,8 @@ pub fn goodbye() -> String {
 }
 ```
 
-Finally, modify your `src/japanese/mod.rs` to read like this:
+<!-- Finally, modify your `src/japanese/mod.rs` to read like this: -->
+最後に、 `src/japanese/mod.rs` を以下のように変更します。
 
 ```rust,ignore
 pub use self::greetings::hello;
@@ -560,31 +566,36 @@ mod greetings;
 mod farewells;
 ```
 
-The `pub use` declaration brings the function into scope at this part of our
+<!-- The `pub use` declaration brings the function into scope at this part of our
 module hierarchy. Because we’ve `pub use`d this inside of our `japanese`
 module, we now have a `phrases::japanese::hello()` function and a
 `phrases::japanese::goodbye()` function, even though the code for them lives in
 `phrases::japanese::greetings::hello()` and
 `phrases::japanese::farewells::goodbye()`. Our internal organization doesn’t
-define our external interface.
+define our external interface. -->
+`pub use` 宣言は関数をモジュール階層のここのスコープへ持ち込みます。`japanese` モジュールの中で `pub use` したため、 `phrases::japanese::greetings::hello()` と `phrases::japanese::farewells::goodbye()` にコードがあるのにも関わらず、 `phrases::japanese::hello()` 関数と `phrases::japanese::goodbye()` 関数が使えるようになります。内部の構成は外部向けのインターフェースを特徴付けるものではありません。
 
-Here we have a `pub use` for each function we want to bring into the
+<!-- Here we have a `pub use` for each function we want to bring into the
 `japanese` scope. We could alternatively use the wildcard syntax to include
-everything from `greetings` into the current scope: `pub use self::greetings::*`.
+everything from `greetings` into the current scope: `pub use self::greetings::*`. -->
+ここまでで `japanese` スコープの中に持ち込みたい各関数のために `pub use` を得ました。現在のスコープ内の `greetings` から全てをインクルードする代わりに、 `pub use self::greetings::*` とすることでワイルドカード構文が使えます。
 
-What about the `self`? Well, by default, `use` declarations are absolute paths,
+<!-- What about the `self`? Well, by default, `use` declarations are absolute paths,
 starting from your crate root. `self` makes that path relative to your current
 place in the hierarchy instead. There’s one more special form of `use`: you can
 `use super::` to reach one level up the tree from your current location. Some
 people like to think of `self` as `.` and `super` as `..`, from many shells’
-display for the current directory and the parent directory.
+display for the current directory and the parent directory. -->
+`self` とはなんでしょう? ええっと、デフォルトでは、 `use` 宣言はクレートのルートから始まる絶対パスです。 `self` は代わりに階層の現在位置からの相対パスにします。 `use` にはもう1つ特別な形式があり、現在の位置から1つ上にアクセスするのに `use super::` が使えます。多くのシェルにおけるカレントディレクトリと親ディレクトリの表示になぞらえ、 `.` が `self` で、 `..` が `super` であるという考え方を好む人もそれなりにいます。
 
-Outside of `use`, paths are relative: `foo::bar()` refers to a function inside
+<!-- Outside of `use`, paths are relative: `foo::bar()` refers to a function inside
 of `foo` relative to where we are. If that’s prefixed with `::`, as in
 `::foo::bar()`, it refers to a different `foo`, an absolute path from your
-crate root.
+crate root. -->
+`use` でなければ、パスは相対です。`foo::bar()` は私達のいる所から相対的に `foo` の内側の関数を参照します。 `::foo::bar()` のように `::` から始まるのであれば、クレートのルートからの絶対パスで、先程とは異なる `foo` を参照します。
 
-This will build and run:
+<!-- This will build and run: -->
+これはビルドして実行できます。
 
 ```bash
 $ cargo run
@@ -596,10 +607,12 @@ Hello in Japanese: こんにちは
 Goodbye in Japanese: さようなら
 ```
 
-## Complex imports
+<!-- ## Complex imports -->
+## 複合的なインポート
 
-Rust offers several advanced options that can add compactness and
-convenience to your `extern crate` and `use` statements. Here is an example:
+<!-- Rust offers several advanced options that can add compactness and
+convenience to your `extern crate` and `use` statements. Here is an example: -->
+Rustは `extern crate` ないし `use` 文に簡潔さと利便性を付加できる上級者向けオプションを幾つか提供しています。
 
 ```rust,ignore
 extern crate phrases as sayings;
@@ -617,24 +630,28 @@ fn main() {
 }
 ```
 
-What's going on here?
+<!-- What's going on here? -->
+何が起きているでしょう?
 
-First, both `extern crate` and `use` allow renaming the thing that is being
+<!-- First, both `extern crate` and `use` allow renaming the thing that is being
 imported. So the crate is still called "phrases", but here we will refer
 to it as "sayings". Similarly, the first `use` statement pulls in the
 `japanese::greetings` module from the crate, but makes it available as
 `ja_greetings` as opposed to simply `greetings`. This can help to avoid
-ambiguity when importing similarly-named items from different places.
+ambiguity when importing similarly-named items from different places. -->
+第一に、インポートされているものを `extern crate` と `use` 双方でリネームしています。そのため 「phrases」という名前のクレートであっても、ここでは「sayings」として参照することになります。同様に、始めの `use` 文はクレートから `japanese::greetings` を引き出していますが、単純な `greetings` ではなく `ja_greetings` で利用できるようにしています。これは異なる場所から同じ名前のアイテムをインポートする際、曖昧さを回避するのに役立ちます。
 
-The second `use` statement uses a star glob to bring in _all_ symbols from the
+<!-- The second `use` statement uses a star glob to bring in _all_ symbols from the
 `sayings::japanese::farewells` module. As you can see we can later refer to
 the Japanese `goodbye` function with no module qualifiers. This kind of glob
-should be used sparingly.
+should be used sparingly. -->
+第二の `use` 文では `sayings::japanese::farewells` モジュールから _全ての_ シンボルを持ってくるためにスターグロブを使っています。ご覧の通り、最後にモジュールの修飾無しで日本語の `goodbye` 関数を参照できています。なお、この種のグロブは慎重に使うべきです。
 
-The third `use` statement bears more explanation. It's using "brace expansion"
+<!-- The third `use` statement bears more explanation. It's using "brace expansion"
 globbing to compress three `use` statements into one (this sort of syntax
 may be familiar if you've written Linux shell scripts before). The
-uncompressed form of this statement would be:
+uncompressed form of this statement would be: -->
+第三の `use` 文はより詳細な説明を要します。これは3つの `use` 文を1つに圧縮するグロブ「中括弧展開」を使用しています（以前にLinuxのシェルスクリプトを書いたことがあるなら、この種の構文は慣れていることでしょう）。この文を展開した形式は以下のようになります。
 
 ```rust,ignore
 use sayings::english;
@@ -642,6 +659,7 @@ use sayings::english::greetings as en_greetings;
 use sayings::english::farewells as en_farewells;
 ```
 
-As you can see, the curly brackets compress `use` statements for several items
+<!-- As you can see, the curly brackets compress `use` statements for several items
 under the same path, and in this context `self` just refers back to that path.
-Note: The curly brackets cannot be nested or mixed with star globbing.
+Note: The curly brackets cannot be nested or mixed with star globbing. -->
+ご覧の通り、波括弧は同一パス下にある幾つかのアイテムに対する `use` 文を圧縮します。また、この文脈における `self` はパスの1つ手前を参照するだけです。（訳注: `sayings::english::{self}` の `self` が指す1つ手前は `sayings::english` ）注意: 波括弧はネストできず、スターグロブと混ぜるとこともできません。

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -6,7 +6,7 @@ engineering practice to split it up into a bunch of smaller pieces, and then
 fit them together. It’s also important to have a well-defined interface, so
 that some of your functionality is private, and some is public. To facilitate
 these kinds of things, Rust has a module system. -->
-プロジェクトが大きくなり始めた際に、コードを幾つかのまとまりに分割しそれらでプロジェクトを組み立てるのはソフトウェア工学における優れた慣例だと考えられています。機能の一部をプライベートとし、かつ幾つかをパブリックとできるように、はっきりと定義されたインターフェースも重要となります。こういった事柄を容易にするため、Rustはモジュールシステムを有しています。
+プロジェクトが大きくなり始めた際に、コードを小さなまとまりに分割しそれらでプロジェクトを組み立てるのはソフトウェア工学における優れた慣例だと考えられています。幾つかの機能をプライベートとし、また幾つかをパブリックとできるように、はっきりと定義されたインターフェースも重要となります。こういった事柄を容易にするため、Rustはモジュールシステムを有しています。
 
 <!-- # Basic terminology: Crates and Modules -->
 # 基本的な専門用語: クレートとモジュール
@@ -16,18 +16,18 @@ these kinds of things, Rust has a module system. -->
 languages. Hence “Cargo” as the name of Rust’s package management tool: you
 ship your crates to others with Cargo. Crates can produce an executable or a
 library, depending on the project. -->
-Rustはモジュールシステムに関連して、「クレート」(crate)と「モジュール」(module)という2つの用語を明確に分けています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってあなたのクレートを船で出荷し他のユーザに公開するわけです。クレートは実行形式かライブラリをプロジェクトに応じて作成できます。
+Rustはモジュールシステムに関連して「クレート」(crate)と「モジュール」(module)という2つの用語を明確に区別しています。クレートは他の言語における「ライブラリ」や「パッケージ」と同じ意味です。このことからRustのパッケージマネジメントツールの名前を「Cargo」としています。（訳注: crateとは枠箱のことであり、cargoは船荷を指します）Cargoを使ってクレートを出荷し他のユーザに公開するわけです。クレートは実行形式かライブラリをプロジェクトに応じて作成できます。
 
 <!-- Each crate has an implicit *root module* that contains the code for that crate.
 You can then define a tree of sub-modules under that root module. Modules allow
 you to partition your code within the crate itself. -->
-各クレートは自身のコードが入っている *ルートモジュール* (root module)を暗黙的に持っています。この時ルートモジュール下にはサブモジュールの木が定義できます。モジュールによりクレート内でコードを分割できます。
+各クレートは自身のコードが入っている *ルートモジュール* (root module)を暗黙的に持っています。そしてルートモジュール下にはサブモジュールの木が定義できます。モジュールによりクレート内でコードを分割できます。
 
 <!-- As an example, let’s make a *phrases* crate, which will give us various phrases
 in different languages. To keep things simple, we’ll stick to ‘greetings’ and
 ‘farewells’ as two kinds of phrases, and use English and Japanese (日本語) as
 two languages for those phrases to be in. We’ll use this module layout: -->
-例として、 *phrases* クレートを作ってみます。これには異なる言語で幾つかのフレーズを入れます。問題の単純さを保つために、2種類のフレーズとして「greetings」と「farewells」に固定し、これらフレーズを表すための2つの言語として英語と日本語を使うことにします。
+例として、 *phrases* クレートを作ってみます。これに異なる言語で幾つかのフレーズを入れます。問題の単純さを保つために、2種類のフレーズ「greetings」と「farewells」のみとし、これらフレーズを表すための2つの言語として英語と日本語を使うことにします。モジュールのレイアウトは以下のようになります。
 
 ```text
                                     +-----------+
@@ -52,7 +52,7 @@ two languages for those phrases to be in. We’ll use this module layout: -->
 <!-- In this example, `phrases` is the name of our crate. All of the rest are
 modules.  You can see that they form a tree, branching out from the crate
 *root*, which is the root of the tree: `phrases` itself. -->
-この例において、 `phrases` はクレートの名前です。それ以外の全てはモジュールです。それらが木の形をしており、クレートの *根* から枝分かれしていることが分かります。そして木の根は `phrases` それ自身です。
+この例において、 `phrases` がクレートの名前で、それ以外の全てはモジュールです。それらが木の形をしており、クレートの *ルート* から枝分かれしていることが分かります。そして木のルートは `phrases` それ自身です。
 
 <!-- Now that we have a plan, let’s define these modules in code. To start,
 generate a new crate with Cargo: -->
@@ -64,7 +64,7 @@ $ cd phrases
 ```
 
 <!-- If you remember, this generates a simple project for us: -->
-このコマンドを覚えていれば、Cargoがシンプルなプロジェクトを生成してくれます。
+これを覚えておけば、Cargoが単純なプロジェクトを生成してくれます。
 
 ```bash
 $ tree .
@@ -85,7 +85,7 @@ above. -->
 
 <!-- To define each of our modules, we use the `mod` keyword. Let’s make our
 `src/lib.rs` look like this: -->
-それぞれのモジュールを定義するために、 `mod` キーワードを使います。 `src/lib.rs` を以下のようにします。
+それぞれのモジュールを定義するために、 `mod` キーワードを使います。 `src/lib.rs` を以下のようにしましょう。
 
 ```rust
 mod english {
@@ -108,7 +108,7 @@ mod japanese {
 <!-- After the `mod` keyword, you give the name of the module. Module names follow
 the conventions for other Rust identifiers: `lower_snake_case`. The contents of
 each module are within curly braces (`{}`). -->
-`mod` キーワードの後、モジュールの名前を与えます。モジュール名は他のRustの識別子の慣例に従います。つまり `lower_snake_case` です。各モジュールの内容は波括弧( `{}` )の中に定義します。
+`mod` キーワードの後、モジュールの名前を与えます。モジュール名はRustの他の識別子の慣例に従います。つまり `lower_snake_case` です。各モジュールの内容は波括弧( `{}` )の中に書きます。
 
 <!-- Within a given `mod`, you can declare sub-`mod`s. We can refer to sub-modules
 with double-colon (`::`) notation: our four nested modules are
@@ -117,11 +117,12 @@ with double-colon (`::`) notation: our four nested modules are
 parent module, the names don’t conflict: `english::greetings` and
 `japanese::greetings` are distinct, even though their names are both
 `greetings`. -->
-与えられた `mod` 内で、サブ `mod` を定義することができます。サブモジュールは2重コロン( `::` )記法で参照できます。先程定義した4つのネストされたモジュールは `english::greetings` 、 `english::farewells` 、 `japanese::greetings` 、そして `japanese::farewells` です。これらサブモジュールは親モジュール配下の名前空間であるため、名前は競合しません。つまり `english::greetings` と `japanese::greetings` は例え両名が `greetings` であったとしても、明確に区別されます。
+与えられた `mod` 内で、サブ `mod` を定義することができます。サブモジュールは2重コロン( `::` )記法で参照できます。ネストされた4つのモジュールは `english::greetings` 、 `english::farewells` 、 `japanese::greetings` 、そして `japanese::farewells` です。これらサブモジュールは親モジュール配下の名前空間になるため、名前は競合しません。つまり `english::greetings` と `japanese::greetings` は例え両名が `greetings` であったとしても、明確に区別されます。
 
 <!-- Because this crate does not have a `main()` function, and is called `lib.rs`,
 Cargo will build this crate as a library: -->
 このクレートは `main()` 関数を持たず、 `lib.rs` と名付けられているため、Cargoはこのクレートをライブラリとしてビルドします。
+
 ```bash
 $ cargo build
    Compiling phrases v0.0.1 (file:///home/you/projects/phrases)
@@ -152,7 +153,7 @@ mod english {
 ```
 
 <!-- We can instead declare our module like this: -->
-このようなモジュールが宣言できます。
+以下のようなモジュールが宣言できます。
 
 ```rust,ignore
 mod english;
@@ -160,7 +161,7 @@ mod english;
 
 <!-- If we do that, Rust will expect to find either a `english.rs` file, or a
 `english/mod.rs` file with the contents of our module. -->
-こうすれば、Rustは `english.rs` ファイルか、 `english/mod.rs` ファイルのどちらかにモジュールの内容があるだろうと予期します。
+こうすると、Rustは `english.rs` ファイルか、 `english/mod.rs` ファイルのどちらかにモジュールの内容があるだろうと予想します。
 
 <!-- Note that in these files, you don’t need to re-declare the module: that’s
 already been done with the initial `mod` declaration. -->
@@ -207,7 +208,7 @@ mod japanese;
 on our preference. In this case, because our modules have sub-modules, we’ve
 chosen the second. Both `src/english/mod.rs` and `src/japanese/mod.rs` look
 like this: -->
-これら2つの宣言はRustへ書き手の好みに合わせて `src/english.rs` と `src/japanese.rs` 、または `src/english/mod.rs` と `src/japanese/mod.rs` のどちらかを見よと伝えています。今回の場合、サブモジュールがあるため、私たちは後者を選択しました。 `src/english/mod.rs` と `src/japanese/mod.rs` は両方とも以下のようになっています。
+これら2つの宣言はRustへ書き手の好みに合わせて `src/english.rs` と `src/japanese.rs` 、または `src/english/mod.rs` と `src/japanese/mod.rs` のどちらかを見よと伝えています。今回の場合、サブモジュールがあるため私たちは後者を選択しました。 `src/english/mod.rs` と `src/japanese/mod.rs` は両方とも以下のようになっています。
 
 ```rust,ignore
 mod greetings;
@@ -235,7 +236,7 @@ fn hello() -> String {
 ```
 
 <!-- Put this in `src/english/farewells.rs`: -->
-`src/english/farewells.rs` には以下を入力します。
+`src/english/farewells.rs` に以下を入力します。
 
 ```rust
 fn goodbye() -> String {
@@ -244,7 +245,7 @@ fn goodbye() -> String {
 ```
 
 <!-- Put this in `src/japanese/greetings.rs`: -->
-`src/japanese/greetings.rs` には以下を入力します。
+`src/japanese/greetings.rs` に以下を入力します。
 
 ```rust
 fn hello() -> String {
@@ -255,10 +256,10 @@ fn hello() -> String {
 <!-- Of course, you can copy and paste this from this web page, or just type
 something else. It’s not important that you actually put ‘konnichiwa’ to learn
 about the module system. -->
-勿論、このwebページからコピー&ペーストしたり、単に他の何かをタイプしても構いません。あなたが実際にモジュールシステムについて学ぶために「konnichiwa」と入力するのは重要なことではありません。
+勿論、このwebページからコピー&ペーストしたり、他の何かをタイプしても構いません。実際、モジュールシステムについて学ぶために「konnichiwa」と入力しても問題ありません。
 
 <!-- Put this in `src/japanese/farewells.rs`: -->
-`src/japanese/farewells.rs` には以下を入力します。
+`src/japanese/farewells.rs` に以下を入力します。
 
 ```rust
 fn goodbye() -> String {
@@ -271,7 +272,7 @@ fn goodbye() -> String {
 
 <!-- Now that we have some functionality in our crate, let’s try to use it from
 another crate. -->
-ここまででクレートは幾つかの機能を得ました、それでは他のクレートから使ってみましょう。
+ここまででクレートに幾つかの機能が実装されました、それでは他のクレートから使ってみましょう。
 
 <!-- # Importing External Crates -->
 # 外部クレートのインポート
@@ -296,7 +297,7 @@ fn main() {
 ```
 
 <!-- The `extern crate` declaration tells Rust that we need to compile and link to
-the `phrases` crate. We can then use `phrases`’ modules in this one. As we
+the `phrases` crate. We can then use `phrases` modules in this one. As we
 mentioned earlier, you can use double colons to refer to sub-modules and the
 functions inside of them. -->
 `extern crate` 宣言はRustにコンパイルして `phrases` クレートをリンクせよと伝えます。するとこのクレート内で `phrases` モジュールが使えます。先に述べていたように、2重コロンでサブモジュールとその中の関数を参照できます。
@@ -312,11 +313,11 @@ rather than a library crate. Our package now has two crates: `src/lib.rs` and
 functionality is in a library crate, and the executable crate uses that
 library. This way, other programs can also use the library crate, and it’s also
 a nice separation of concerns. -->
-また、Cargoは `src/main.rs` がライブラリクレートではなくバイナリクレートのルートであることを仮定します。パッケージは今2つのクレートを持っています。 `src/lib.rs` と `src/main.rs` です。ほとんどの機能をライブラリクレート内に置き、実行形式クレートから使用するのは、実行形式クレートとしては非常にありふれたパターンです。この方法で、他のプログラムがライブラリクレートを使うこともできますし、素敵な関心の分離(separation of concerns)でもあります。
+また、Cargoは `src/main.rs` がライブラリクレートではなくバイナリクレートのルートだと仮定します。パッケージには今2つのクレートがあります。 `src/lib.rs` と `src/main.rs` です。ほとんどの機能をライブラリクレート内に置き、実行形式クレートから利用するのがよくあるパターンです。この方法なら他のプログラムがライブラリクレートを使うこともできますし、素敵な関心の分離(separation of concerns)にもなります。
 
 <!-- This doesn’t quite work yet, though. We get four errors that look similar to
 this: -->
-けれどこのままでは動作しません。これに似た4つのエラーが発生します。
+けれどこのままではまだ動作しません。以下に似た4つのエラーが発生します。
 
 ```bash
 $ cargo build
@@ -334,7 +335,7 @@ phrases/src/main.rs:4:5: 4:76 note: expansion site
 
 <!-- By default, everything is private in Rust. Let’s talk about this in some more
 depth. -->
-デフォルトでは、Rustにおける全てはプライベートです。それではこれに関してより詳しく説明しましょう。
+デフォルトでは、Rustにおける全てがプライベートです。それではもっと詳しく説明しましょう。
 
 <!-- # Exporting a Public Interface -->
 # パブリックなインターフェースのエクスポート
@@ -343,7 +344,7 @@ depth. -->
 public, and so private is the default. To make things public, you use the `pub`
 keyword. Let’s focus on the `english` module first, so let’s reduce our `src/main.rs`
 to just this: -->
-Rustはインターフェースのパブリックである部分をきちんと管理することができます。そのためプライベートがデフォルトです。パブリックにするためには、 `pub` キーワードを使います。まずは `english` モジュールに焦点を当てたいので、 `src/main.rs` をこれだけに減らしましょう。
+Rustはインターフェースのパブリックである部分をきっちりと管理します。そのためプライベートがデフォルトです。パブリックにするためには `pub` キーワードを使います。まずは `english` モジュールに焦点を当てたいので、 `src/main.rs` をこれだけに減らしましょう。
 
 ```rust,ignore
 extern crate phrases;
@@ -390,7 +391,7 @@ pub fn goodbye() -> String {
 
 <!-- Now, our crate compiles, albeit with warnings about not using the `japanese`
 functions: -->
-これで、クレートはコンパイルできますが、 `japanese` 関数が使われていないという旨の警告が発生します。
+これでクレートはコンパイルできますが、 `japanese` 関数が使われていないという旨の警告が発生します。
 
 ```bash
 $ cargo run
@@ -411,13 +412,13 @@ Goodbye in English: Goodbye.
 <!-- `pub` also applies to `struct`s and their member fields. In keeping with Rust’s
 tendency toward safety, simply making a `struct` public won't automatically
 make its members public: you must mark the fields individually with `pub`. -->
-`pub` は `struct` や そのメンバーのフィールドにも適用されます。Rustの安全性に関する傾向に合わせ、単に `struct` をパブリックにしても、そのメンバーまでは自動的にパブリックになりません。個々のフィールドに `pub` を付けなければならないのです。
+`pub` は `struct` や そのメンバのフィールドにも使えます。Rustの安全性に対する傾向に合わせ、単に `struct` をパブリックにしてもそのメンバまでは自動的にパブリックになりません。個々のフィールドに `pub` を付ける必要があります。
 
 <!-- Now that our functions are public, we can use them. Great! However, typing out
 `phrases::english::greetings::hello()` is very long and repetitive. Rust has
 another keyword for importing names into the current scope, so that you can
 refer to them with shorter names. Let’s talk about `use`. -->
-現在使える関数はパブリックです。素晴らしい！しかしながら、 `phrases::english::greetings::hello()` を打つのは非常に長くて退屈ですね。Rustには現在のスコープに名前をインポートするもう1つのキーワードがあり、それによってより短い名前で参照できます。それでは `use` について説明しましょう。
+関数がパブリックになり、呼び出せるようになりました。素晴らしい！けれども `phrases::english::greetings::hello()` を打つのは非常に長くて退屈ですね。Rustにはもう1つ、現在のスコープに名前をインポートするキーワードがあるので、それを使えば短い名前で参照できます。では `use` について説明しましょう。
 
 <!-- # Importing Modules with `use` -->
 # `use` でモジュールをインポートする
@@ -442,7 +443,7 @@ fn main() {
 the functions by a much shorter name. By convention, when importing functions, it’s
 considered best practice to import the module, rather than the function directly. In
 other words, you _can_ do this: -->
-2つの `use` の行はローカルスコープの中に各モジュールをインポートしているため、とても短い名前で関数を参照できます。慣習では、関数をインポートするとき、関数を直接するよりもモジュール単位でするのがベストプラクティスだと考えられています。言い換えれば、こうすることも _できる_ わけです。
+2つの `use` の行はローカルスコープの中に各モジュールをインポートしているため、とても短い名前で関数を参照できます。慣習では関数をインポートする場合、関数を直接インポートするよりもモジュール単位でするのがベストプラクティスだと考えられています。言い換えれば、こうすることも _できる_ わけです。
 
 ```rust,ignore
 extern crate phrases;
@@ -461,7 +462,7 @@ naming conflict. In our short program, it’s not a big deal, but as it grows, i
 becomes a problem. If we have conflicting names, Rust will give a compilation
 error. For example, if we made the `japanese` functions public, and tried to do
 this: -->
-しかしこれは慣用的ではありません。これは名前の競合を引き起こす可能性が非常に高いのです。この短いプログラムだと大したことではありませんが、大きくなるにつれ問題になります。名前が競合すると、Rustはコンパイルエラーになります。例えば、 `japanese` 関数をパブリックにして、以下を試してみます。
+しかしこれは慣用的ではありません。名前の競合を引き起こす可能性が非常に高まるからです。この短いプログラムだと大したことではありませんが、長くなるにつれ問題になります。名前が競合するとコンパイルエラーになります。例えば、 `japanese` 関数をパブリックにして、以下を試してみます。
 
 ```rust,ignore
 extern crate phrases;
@@ -476,7 +477,7 @@ fn main() {
 ```
 
 <!-- Rust will give us a compile-time error: -->
-Rustはコンパイル時エラーになります。
+Rustはコンパイル時にエラーを起こします。
 
 ```text
    Compiling phrases v0.0.1 (file:///home/you/projects/phrases)
@@ -509,7 +510,7 @@ use phrases::english::{greetings, farewells};
 <!-- You don’t just use `use` to shorten identifiers. You can also use it inside of your crate
 to re-export a function inside another module. This allows you to present an external
 interface that may not directly map to your internal code organization. -->
-`use` は識別子を短くするためだけに用いるのではありません。他のモジュール内の関数を再エクスポートするためにクレートの中で使うこともできます。これにより内部のコード構成に直接対応しない外部インターフェースを提供できます。
+`use` は識別子を短くするためだけに用いるのではありません。他のモジュール内の関数を再エクスポートするためにクレートの中で使うこともできます。これを使って内部のコード構成そのままではない外部向けインターフェースを提供できます。
 
 <!-- Let’s look at an example. Modify your `src/main.rs` to read like this: -->
 例を見てみましょう。 `src/main.rs` を以下のように変更します。
@@ -573,12 +574,12 @@ module, we now have a `phrases::japanese::hello()` function and a
 `phrases::japanese::greetings::hello()` and
 `phrases::japanese::farewells::goodbye()`. Our internal organization doesn’t
 define our external interface. -->
-`pub use` 宣言は関数をモジュール階層のここのスコープへ持ち込みます。`japanese` モジュールの中で `pub use` したため、 `phrases::japanese::greetings::hello()` と `phrases::japanese::farewells::goodbye()` にコードがあるのにも関わらず、 `phrases::japanese::hello()` 関数と `phrases::japanese::goodbye()` 関数が使えるようになります。内部の構成は外部向けのインターフェースを特徴付けるものではありません。
+`pub use` 宣言は関数をモジュール階層 `phrases::japanese` のスコープへ持ち込みます。`japanese` モジュールの中で `pub use` したため、 `phrases::japanese::greetings::hello()` と `phrases::japanese::farewells::goodbye()` にコードがあるのにも関わらず、 `phrases::japanese::hello()` 関数と `phrases::japanese::goodbye()` 関数が使えるようになります。内部の構成で外部向けのインターフェースが決まるわけではありません。
 
 <!-- Here we have a `pub use` for each function we want to bring into the
 `japanese` scope. We could alternatively use the wildcard syntax to include
 everything from `greetings` into the current scope: `pub use self::greetings::*`. -->
-ここまでで `japanese` スコープの中に持ち込みたい各関数のために `pub use` を得ました。現在のスコープ内の `greetings` から全てをインクルードする代わりに、 `pub use self::greetings::*` とすることでワイルドカード構文が使えます。
+ここで `japanese` スコープの中に持ち込みたい各関数のための `pub use` を得ました。 `greetings` から現在のスコープへ全てをインクルードする代わりに、 `pub use self::greetings::*` とすることでワイルドカード構文が使えます。
 
 <!-- What about the `self`? Well, by default, `use` declarations are absolute paths,
 starting from your crate root. `self` makes that path relative to your current
@@ -586,13 +587,13 @@ place in the hierarchy instead. There’s one more special form of `use`: you ca
 `use super::` to reach one level up the tree from your current location. Some
 people like to think of `self` as `.` and `super` as `..`, from many shells’
 display for the current directory and the parent directory. -->
-`self` とはなんでしょう? ええっと、デフォルトでは、 `use` 宣言はクレートのルートから始まる絶対パスです。 `self` は代わりに階層の現在位置からの相対パスにします。 `use` にはもう1つ特別な形式があり、現在の位置から1つ上にアクセスするのに `use super::` が使えます。多くのシェルにおけるカレントディレクトリと親ディレクトリの表示になぞらえ、 `.` が `self` で、 `..` が `super` であるという考え方を好む人もそれなりにいます。
+`self` とはなんでしょう? ええっと、デフォルトでは、 `use` 宣言はクレートのルートから始まる絶対パスです。 `self` は代わりに現在位置からの相対パスにします。 `use` にはもう1つ特別な形式があり、現在位置から1つ上へのアクセスに `use super::` が使えます。多くのシェルにおけるカレントディレクトリと親ディレクトリの表示になぞらえ、 `.` が `self` で、 `..` が `super` であるという考え方を好む人もそれなりにいます。
 
 <!-- Outside of `use`, paths are relative: `foo::bar()` refers to a function inside
 of `foo` relative to where we are. If that’s prefixed with `::`, as in
 `::foo::bar()`, it refers to a different `foo`, an absolute path from your
 crate root. -->
-`use` でなければ、パスは相対です。`foo::bar()` は私達のいる所から相対的に `foo` の内側の関数を参照します。 `::foo::bar()` のように `::` から始まるのであれば、クレートのルートからの絶対パスで、先程とは異なる `foo` を参照します。
+`use` でなければ、パスは相対です。`foo::bar()` は私達のいる場所から相対的に `foo` の内側の関数を参照します。 `::foo::bar()` のように `::` から始まるのであれば、クレートのルートからの絶対パスで、先程とは異なる `foo` を参照します。
 
 <!-- This will build and run: -->
 これはビルドして実行できます。
@@ -612,7 +613,7 @@ Goodbye in Japanese: さようなら
 
 <!-- Rust offers several advanced options that can add compactness and
 convenience to your `extern crate` and `use` statements. Here is an example: -->
-Rustは `extern crate` ないし `use` 文に簡潔さと利便性を付加できる上級者向けオプションを幾つか提供しています。
+`extern crate` 及び `use` 文に対し、Rustは簡潔さと利便性を付加できる上級者向けオプションを幾つか提供しています。以下が例になります。
 
 ```rust,ignore
 extern crate phrases as sayings;
@@ -645,13 +646,13 @@ ambiguity when importing similarly-named items from different places. -->
 `sayings::japanese::farewells` module. As you can see we can later refer to
 the Japanese `goodbye` function with no module qualifiers. This kind of glob
 should be used sparingly. -->
-第二の `use` 文では `sayings::japanese::farewells` モジュールから _全ての_ シンボルを持ってくるためにスターグロブを使っています。ご覧の通り、最後にモジュールの修飾無しで日本語の `goodbye` 関数を参照できています。なお、この種のグロブは慎重に使うべきです。
+第二の `use` 文では `sayings::japanese::farewells` モジュールから _全ての_ シンボルを持ってくるためにスターグロブを使っています。ご覧の通り、最後にモジュールの修飾無しで日本語の `goodbye` 関数を参照できています。なお、この類のグロブは慎重に使うべきです。
 
 <!-- The third `use` statement bears more explanation. It's using "brace expansion"
 globbing to compress three `use` statements into one (this sort of syntax
 may be familiar if you've written Linux shell scripts before). The
 uncompressed form of this statement would be: -->
-第三の `use` 文はより詳細な説明を要します。これは3つの `use` 文を1つに圧縮するグロブ「中括弧展開」を使用しています（以前にLinuxのシェルスクリプトを書いたことがあるなら、この種の構文は慣れていることでしょう）。この文を展開した形式は以下のようになります。
+第三の `use` 文はもっと詳細な説明が必要です。これは3つの `use` 文を1つに圧縮するグロブ「中括弧展開」を用いています（以前にLinuxのシェルスクリプトを書いたことがあるなら、この類の構文は慣れていることでしょう）。この文を展開した形式は以下のようになります。
 
 ```rust,ignore
 use sayings::english;
@@ -662,4 +663,4 @@ use sayings::english::farewells as en_farewells;
 <!-- As you can see, the curly brackets compress `use` statements for several items
 under the same path, and in this context `self` just refers back to that path.
 Note: The curly brackets cannot be nested or mixed with star globbing. -->
-ご覧の通り、波括弧は同一パス下にある幾つかのアイテムに対する `use` 文を圧縮します。また、この文脈における `self` はパスの1つ手前を参照するだけです。（訳注: `sayings::english::{self}` の `self` が指す1つ手前は `sayings::english` ）注意: 波括弧はネストできず、スターグロブと混ぜるとこともできません。
+ご覧の通り、波括弧は同一パス下にある幾つかのアイテムに対する `use` 文を圧縮します。また、この文脈における `self` はパスの1つ手前を参照するだけです。（訳注: `sayings::english::{self}` の `self` が指す1つ手前は `sayings::english` です）注意: 波括弧はネストできず、スターグロブと混ぜるとこともできません。

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -1,4 +1,5 @@
-% Crates and Modules
+% クレートとモジュール
+<!-- % Crates and Modules -->
 
 When a project starts getting large, it’s considered good software
 engineering practice to split it up into a bunch of smaller pieces, and then

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -9,7 +9,7 @@ these kinds of things, Rust has a module system. -->
 プロジェクトが大きくなり始めた際に、コードを小さなまとまりに分割しそれらでプロジェクトを組み立てるのはソフトウェア工学における優れた慣例だと考えられています。幾つかの機能をプライベートとし、また幾つかをパブリックとできるように、はっきりと定義されたインターフェースも重要となります。こういった事柄を容易にするため、Rustはモジュールシステムを有しています。
 
 <!-- # Basic terminology: Crates and Modules -->
-# 基本的な専門用語: クレートとモジュール
+# 基本的な用語: クレートとモジュール
 
 <!-- Rust has two distinct terms that relate to the module system: ‘crate’ and
 ‘module’. A crate is synonymous with a ‘library’ or ‘package’ in other
@@ -64,7 +64,7 @@ $ cd phrases
 ```
 
 <!-- If you remember, this generates a simple project for us: -->
-これを覚えておけばCargoが単純なプロジェクトを生成してくれます。
+聡明な読者ならご記憶かと思いますがCargoが単純なプロジェクトを生成してくれます。
 
 ```bash
 $ tree .
@@ -256,7 +256,7 @@ fn hello() -> String {
 <!-- Of course, you can copy and paste this from this web page, or just type
 something else. It’s not important that you actually put ‘konnichiwa’ to learn
 about the module system. -->
-勿論、このwebページからコピー&ペーストしたり、他の何かをタイプしても構いません。実際、モジュールシステムについて学ぶために「konnichiwa」と入力しても問題ありません。
+勿論、このwebページからコピー&ペーストしたり、他の何かをタイプしても構いません。モジュールシステムを学ぶのに「konnichiwa」と入力するのは重要なことではありません。
 
 <!-- Put this in `src/japanese/farewells.rs`: -->
 `src/japanese/farewells.rs` に以下を入力します。
@@ -282,7 +282,7 @@ our library. -->
 前節でライブラリクレートができました。インポートしこのライブラリを用いた実行形式クレートを作成しましょう。
 
 <!-- Make a `src/main.rs` and put this in it (it won’t quite compile yet): -->
-`src/main.rs` を作成し配置します。（これはまだ全くコンパイルされていません）
+`src/main.rs` を作成し配置します。（このコンパイルはまだ通りません）
 
 ```rust,ignore
 extern crate phrases;
@@ -579,7 +579,7 @@ define our external interface. -->
 <!-- Here we have a `pub use` for each function we want to bring into the
 `japanese` scope. We could alternatively use the wildcard syntax to include
 everything from `greetings` into the current scope: `pub use self::greetings::*`. -->
-ここで `japanese` スコープの中に持ち込みたい各関数のための `pub use` を得ました。 `greetings` から現在のスコープへ全てをインクルードする代わりに、 `pub use self::greetings::*` とすることでワイルドカード構文が使えます。
+`pub use` によって各関数を `japanese` スコープの中に持ち込めるようになりました。 `greetings` から現在のスコープへ全てをインクルードする代わりに、 `pub use self::greetings::*` とすることでワイルドカード構文が使えます。
 
 <!-- What about the `self`? Well, by default, `use` declarations are absolute paths,
 starting from your crate root. `self` makes that path relative to your current
@@ -652,7 +652,7 @@ should be used sparingly. -->
 globbing to compress three `use` statements into one (this sort of syntax
 may be familiar if you've written Linux shell scripts before). The
 uncompressed form of this statement would be: -->
-第三の `use` 文はもっと詳細な説明が必要です。これは3つの `use` 文を1つに圧縮するグロブ「中括弧展開」を用いています（以前にLinuxのシェルスクリプトを書いたことがあるなら、この類の構文は慣れていることでしょう）。この文を展開した形式は以下のようになります。
+第三の `use` 文はもっと詳しい説明が必要です。これは3つの `use` 文を1つに圧縮するグロブ「中括弧展開」を用いています（以前にLinuxのシェルスクリプトを書いたことがあるなら、この類の構文は慣れていることでしょう）。この文を展開した形式は以下のようになります。
 
 ```rust,ignore
 use sayings::english;

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -503,7 +503,7 @@ use phrases::english::farewells;
 use phrases::english::{greetings, farewells};
 ```
 
-## Re-exporting with `pub use`
+<!-- ## Re-exporting with `pub use` -->
 ## `pub use` による再エクスポート
 
 You don’t just use `use` to shorten identifiers. You can also use it inside of your crate

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -299,7 +299,7 @@ fn main() {
 the `phrases` crate. We can then use `phrases`’ modules in this one. As we
 mentioned earlier, you can use double colons to refer to sub-modules and the
 functions inside of them. -->
-`extern crate` 宣言はRustにコンパイルして `phrases` クレートをリンクせよと伝えます。するとこのクレート内で `phrases` モジュールが使えます。早期に言及していたように、2重コロンでサブモジュールとその中の関数を参照できます。
+`extern crate` 宣言はRustにコンパイルして `phrases` クレートをリンクせよと伝えます。するとこのクレート内で `phrases` モジュールが使えます。先に述べていたように、2重コロンでサブモジュールとその中の関数を参照できます。
 
 <!-- (Note: when importing a crate that has dashes in its name "like-this", which is
 not a valid Rust identifier, it will be converted by changing the dashes to
@@ -312,7 +312,7 @@ rather than a library crate. Our package now has two crates: `src/lib.rs` and
 functionality is in a library crate, and the executable crate uses that
 library. This way, other programs can also use the library crate, and it’s also
 a nice separation of concerns. -->
-また、Cargoは `src/main.rs` がライブラリクレートではなくバイナリクレートのルートであることを仮定します。パッケージは今2つのクレートを持っています。 `src/lib.rs` と `src/main.rs` です。ほとんどの機能をライブラリクレート内に置き、実行形式クレートから使用するのは、実行形式クレートとしては非常にありふれたパターンです。この方法で、他のプログラムもライブラリクレートを使うことできますし、素敵な関心の分離(separation of concerns)でもあります。
+また、Cargoは `src/main.rs` がライブラリクレートではなくバイナリクレートのルートであることを仮定します。パッケージは今2つのクレートを持っています。 `src/lib.rs` と `src/main.rs` です。ほとんどの機能をライブラリクレート内に置き、実行形式クレートから使用するのは、実行形式クレートとしては非常にありふれたパターンです。この方法で、他のプログラムがライブラリクレートを使うこともできますし、素敵な関心の分離(separation of concerns)でもあります。
 
 <!-- This doesn’t quite work yet, though. We get four errors that look similar to
 this: -->
@@ -339,10 +339,11 @@ depth. -->
 <!-- # Exporting a Public Interface -->
 # パブリックなインターフェースのエクスポート
 
-Rust allows you to precisely control which aspects of your interface are
+<!-- Rust allows you to precisely control which aspects of your interface are
 public, and so private is the default. To make things public, you use the `pub`
 keyword. Let’s focus on the `english` module first, so let’s reduce our `src/main.rs`
-to just this:
+to just this: -->
+Rustはインターフェースのパブリックである部分をきちんと管理することができます。そのためプライベートがデフォルトです。パブリックにするためには、 `pub` キーワードを使います。まずは `english` モジュールに焦点を当てたいので、 `src/main.rs` をこれだけに減らしましょう。
 
 ```rust,ignore
 extern crate phrases;
@@ -353,14 +354,16 @@ fn main() {
 }
 ```
 
-In our `src/lib.rs`, let’s add `pub` to the `english` module declaration:
+<!-- In our `src/lib.rs`, let’s add `pub` to the `english` module declaration: -->
+`src/lib.rs` 内にて、 `english` モジュールの宣言に `pub` を加えましょう。
 
 ```rust,ignore
 pub mod english;
 mod japanese;
 ```
 
-And in our `src/english/mod.rs`, let’s make both `pub`:
+<!-- And in our `src/english/mod.rs`, let’s make both `pub`: -->
+また `src/english/mod.rs` にて、両方とも `pub` にしましょう。
 
 ```rust,ignore
 pub mod greetings;
@@ -368,6 +371,7 @@ pub mod farewells;
 ```
 
 In our `src/english/greetings.rs`, let’s add `pub` to our `fn` declaration:
+`src/english/greetings.rs` にて、 `fn` の宣言に `pub` を加えましょう。
 
 ```rust,ignore
 pub fn hello() -> String {
@@ -376,6 +380,7 @@ pub fn hello() -> String {
 ```
 
 And also in `src/english/farewells.rs`:
+また `src/english/farewells.rs` にもです。
 
 ```rust,ignore
 pub fn goodbye() -> String {
@@ -383,8 +388,9 @@ pub fn goodbye() -> String {
 }
 ```
 
-Now, our crate compiles, albeit with warnings about not using the `japanese`
-functions:
+<!-- Now, our crate compiles, albeit with warnings about not using the `japanese`
+functions: -->
+これで、クレートはコンパイルできますが、 `japanese` 関数が使われていないという旨の警告が発生します。
 
 ```bash
 $ cargo run
@@ -402,16 +408,19 @@ Hello in English: Hello!
 Goodbye in English: Goodbye.
 ```
 
-`pub` also applies to `struct`s and their member fields. In keeping with Rust’s
+<!-- `pub` also applies to `struct`s and their member fields. In keeping with Rust’s
 tendency toward safety, simply making a `struct` public won't automatically
-make its members public: you must mark the fields individually with `pub`.
+make its members public: you must mark the fields individually with `pub`. -->
+`pub` は `struct` や そのメンバーのフィールドにも適用されます。Rustの安全性に関する傾向に合わせ、単に `struct` をパブリックにしても、そのメンバーまでは自動的にパブリックになりません。個々のフィールドに `pub` を付けなければならないのです。
 
-Now that our functions are public, we can use them. Great! However, typing out
+<!-- Now that our functions are public, we can use them. Great! However, typing out
 `phrases::english::greetings::hello()` is very long and repetitive. Rust has
 another keyword for importing names into the current scope, so that you can
-refer to them with shorter names. Let’s talk about `use`.
+refer to them with shorter names. Let’s talk about `use`. -->
+現在使える関数はパブリックです。素晴らしい！しかしながら、 `phrases::english::greetings::hello()` を打つのは非常に長くて退屈ですね。Rustには現在のスコープに名前をインポートするもう1つのキーワードがあり、それによってより短い名前で参照できます。それでは `use` について説明しましょう。
 
-# Importing Modules with `use`
+<!-- # Importing Modules with `use` -->
+# `use` でモジュールをインポートする
 
 Rust has a `use` keyword, which allows us to import names into our local scope.
 Let’s change our `src/main.rs` to look like this:

--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -83,8 +83,9 @@ above. -->
 <!-- # Defining Modules -->
 # モジュールを定義する
 
-To define each of our modules, we use the `mod` keyword. Let’s make our
-`src/lib.rs` look like this:
+<!-- To define each of our modules, we use the `mod` keyword. Let’s make our
+`src/lib.rs` look like this: -->
+それぞれのモジュールを定義するために、 `mod` キーワードを使います。 `src/lib.rs` を以下のようにします。
 
 ```rust
 mod english {
@@ -104,21 +105,23 @@ mod japanese {
 }
 ```
 
-After the `mod` keyword, you give the name of the module. Module names follow
+<!-- After the `mod` keyword, you give the name of the module. Module names follow
 the conventions for other Rust identifiers: `lower_snake_case`. The contents of
-each module are within curly braces (`{}`).
+each module are within curly braces (`{}`). -->
+`mod` キーワードの後、モジュールの名前を与えます。モジュール名は他のRustの識別子の慣例に従います。つまり `lower_snake_case` です。各モジュールの内容は波括弧( `{}` )の中に定義します。
 
-Within a given `mod`, you can declare sub-`mod`s. We can refer to sub-modules
+<!-- Within a given `mod`, you can declare sub-`mod`s. We can refer to sub-modules
 with double-colon (`::`) notation: our four nested modules are
 `english::greetings`, `english::farewells`, `japanese::greetings`, and
 `japanese::farewells`. Because these sub-modules are namespaced under their
 parent module, the names don’t conflict: `english::greetings` and
 `japanese::greetings` are distinct, even though their names are both
-`greetings`.
+`greetings`. -->
+与えられた `mod` 内で、サブ `mod` を定義することができます。サブモジュールは2重コロン( `::` )記法で参照できます。先程定義した4つのネストされたモジュールは `english::greetings` 、 `english::farewells` 、 `japanese::greetings` 、そして `japanese::farewells` です。これらサブモジュールは親モジュール配下の名前空間であるため、名前は衝突しません。つまり `english::greetings` と `japanese::greetings` は例え両名が `greetings` であったとしても、明確に区別されます。
 
-Because this crate does not have a `main()` function, and is called `lib.rs`,
-Cargo will build this crate as a library:
-
+<!-- Because this crate does not have a `main()` function, and is called `lib.rs`,
+Cargo will build this crate as a library: -->
+このクレートは `main()` 関数を持たず、 `lib.rs` と名付けられているため、Cargoはこのクレートをライブラリとしてビルドします。
 ```bash
 $ cargo build
    Compiling phrases v0.0.1 (file:///home/you/projects/phrases)
@@ -126,10 +129,12 @@ $ ls target/debug
 build  deps  examples  libphrases-a7448e02a0468eaa.rlib  native
 ```
 
-`libphrases-hash.rlib` is the compiled crate. Before we see how to use this
-crate from another crate, let’s break it up into multiple files.
+<!-- `libphrases-hash.rlib` is the compiled crate. Before we see how to use this
+crate from another crate, let’s break it up into multiple files. -->
+`libphrases-hash.rlib` はコンパイルされたクレートです。このクレートを他のクレートから使う方法を見る前に、複数のファイルに分割してみましょう。
 
-# Multiple file crates
+<!-- # Multiple file crates -->
+# 複数のファイルによるクレート
 
 If each crate were just one file, these files would get very large. It’s often
 easier to split up crates into multiple files, and Rust supports this in two


### PR DESCRIPTION
暫定訳完了
#### 相談

「〇〇のために△△が(あります|します|etc...)」
がどうしても直訳的になってしまうため、違和感が無い物は文章を反転させて、
「△△を使って〇〇が(できます|します)」
というタームを前に持ってくる文章にしたいと考えています。どうでしょうか?
