### PR TITLE
原文のコメントアウト忘れを修正

### DIFF
--- a/1.6/ja/book/crates-and-modules.md
+++ b/1.6/ja/book/crates-and-modules.md
@@ -371,7 +371,7 @@ pub mod greetings;
 pub mod farewells;
 ```
 
-In our `src/english/greetings.rs`, let’s add `pub` to our `fn` declaration:
+<!-- In our `src/english/greetings.rs`, let’s add `pub` to our `fn` declaration: -->
 `src/english/greetings.rs` にて、 `fn` の宣言に `pub` を加えましょう。
 
 ```rust,ignore
@@ -380,7 +380,7 @@ pub fn hello() -> String {
 }
 ```
 
-And also in `src/english/farewells.rs`:
+<!-- And also in `src/english/farewells.rs`: -->
 また `src/english/farewells.rs` にもです。
 
 ```rust,ignore


### PR DESCRIPTION
https://rust-lang-ja.github.io/the-rust-programming-language-ja/1.6/book/crates-and-modules.html

4.25. クレートとモジュールにて、原文のコメントアウト忘れがあったので修正しました。
