### PR TITLE
Revise paragraph in "ライフタイムの省略"

### DIFF
--- a/1.6/ja/book/lifetimes.md
+++ b/1.6/ja/book/lifetimes.md
@@ -399,10 +399,10 @@ let x: &'static i32 = &FOO;
 <!-- this with only three easily memorizable and unambiguous rules. This makes -->
 <!-- lifetime elision a shorthand for writing an item signature, while not hiding -->
 <!-- away the actual types involved as full local inference would if applied to it. -->
-Rustは関数本文での強力なローカルの型推論をサポートします。しかし、要素のシグネチャでは要素のシグネチャだけで型が分かるように、型についての推論が許されていません。
-しかし、人間工学的な推論のために、非常に制限された「ライフタイムの省略」と呼ばれる2番目の推論アルゴリズムが関数のシグネチャでは適用されます。
-それはシグネチャのコンポーネントだけに基づき、関数本文には基づかずに、ライフタイムパラメータだけを推論します。そしてそのアルゴリズムはこれをたった3つの覚えやすく明確なルールに従って行います。
-これはライフタイムの省略を要素のシグネチャを書くための省略表現にします。しかし、完全なローカルの推論が適用されたときに得られるであろう全ての型を隠すことはできません。
+Rustは関数本体の部分では強力なローカル型推論をサポートします。しかし要素のシグネチャの部分では、型が要素のシグネチャだけでわかるようにするため、（型推論が）許されていません。
+とはいえ、エルゴノミック（人間にとっての扱いやすさ）の理由により、"ライフタイムの省略"と呼ばれている、非常に制限された第二の推論アルゴリズムがシグネチャの部分に適用されます。
+その推論はシグネチャのコンポーネントだけに基づき、関数本体には基づかず、ライフタイムパラメータだけを推論します。そしてたった3つの覚えやすく明確なルールに従って行います。
+ライフタイムの省略で要素のシグネチャを短く書くことができます。しかしローカル型推論が適用されるときのように実際の型を隠すことはできません。
 
 <!-- When talking about lifetime elision, we use the term *input lifetime* and -->
 <!-- *output lifetime*. An *input lifetime* is a lifetime associated with a parameter -->


### PR DESCRIPTION
[ライフタイムの省略](https://github.com/niku/the-rust-programming-language-ja/blob/e19a047e17154d2f23f0dca464c27d5a6f166f93/1.6/ja/book/lifetimes.md#%E3%83%A9%E3%82%A4%E3%83%95%E3%82%BF%E3%82%A4%E3%83%A0%E3%81%AE%E7%9C%81%E7%95%A5)の最初の段落が意味を取りにくかったので相談です．

こんな感じで改善してみようかと思うのですが，いかがでしょうか．
訳にはあまり自信がありません．

もしOKそうなら適用してプルリクエストをちゃんと作ります．

---

> Rust supports powerful local type inference in function bodies, but it's forbidden in item signatures to allow reasoning about the types based on the item signature alone.

Rust は関数本体の部分では強力なローカル型推論をサポートします。しかし要素のシグネチャの部分では、型が要素のシグネチャだけでわかるようにするため，(型推論が)許されていません。

> However, for ergonomic reasons a very restricted secondary inference algorithm called “lifetime elision” applies in function signatures.

とはいえ、人間工学的な理由により(訳注:人間が読みやすいように)"ライフタイムの省略"と呼ばれている、非常に制限された第二の推論アルゴリズムはシグネチャの部分に適用されます。

> It infers only based on the signature components themselves and not based on the body of the function, only infers lifetime parameters, and does this with only three easily memorizable and unambiguous rules.

その推論はシグネチャのコンポーネントだけに基づき、関数本体には基づかず、ライフタイムパラメータだけを推論します。そしてたった3つの覚えやすく明確なルールに従って行います。

> This makes lifetime elision a shorthand for writing an item signature, while not hiding away the actual types involved as full local inference would if applied to it.

ライフタイムの省略で要素のシグネチャを短く書くことができます。しかしローカル型推論が適用されるときのように実際の型を隠すことはできません。
