### PR TITLE
CircleCIにHTMLの自動push機能を追加

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+general:
+  branches:
+    ignore:
+      - gh-pages
+
 machine:
   timezone:
     Asia/Tokyo
@@ -14,9 +19,11 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install curl file gcc git make openssh-client
     - mkdir -p $HOME/rust
+    # Install rustc and cargo, or use cached ones.
     - ./tools/circleci/setup-rust.sh $RUST_HOME $RUST_NIGHTLY_RELEASE_DATE
     - rustc --version --verbose
     - cargo --version --verbose
+    # Install rustbook, or use cached one.
     - cargo install --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH || true
     - rustbook help
   cache_directories:
@@ -29,15 +36,29 @@ test:
     - make VERSION=1.6
 
   post:
+    # Save 1.9 contents as an artifact
     - mkdir $CIRCLE_ARTIFACTS/1.9
-    - mv public/1.9/index.html $CIRCLE_ARTIFACTS/1.9
-    - mv public/1.9/book $CIRCLE_ARTIFACTS/1.9
-    - mv public/1.9/*.inc public/1.9/*.css public/1.9/*.js $CIRCLE_ARTIFACTS/1.9
+    - cp -p public/1.9/index.html $CIRCLE_ARTIFACTS/1.9
+    - cp -rp public/1.9/book $CIRCLE_ARTIFACTS/1.9
+    - cp -rp public/1.9/*.inc public/1.9/*.css public/1.9/*.js $CIRCLE_ARTIFACTS/1.9
     - tar cJf public-1.9.txz public/1.9
     - mv public-1.9.txz $CIRCLE_ARTIFACTS
+    # Save 1.6 contents as an artifact
     - mkdir $CIRCLE_ARTIFACTS/1.6
-    - mv public/1.6/index.html $CIRCLE_ARTIFACTS/1.6
-    - mv public/1.6/book $CIRCLE_ARTIFACTS/1.6
-    - mv public/1.6/*.inc public/1.6/*.css public/1.6/*.js $CIRCLE_ARTIFACTS/1.6
+    - cp -p public/1.6/index.html $CIRCLE_ARTIFACTS/1.6
+    - cp -rp public/1.6/book $CIRCLE_ARTIFACTS/1.6
+    - cp -rp public/1.6/*.inc public/1.6/*.css public/1.6/*.js $CIRCLE_ARTIFACTS/1.6
     - tar cJf public-1.6.txz public/1.6
     - mv public-1.6.txz $CIRCLE_ARTIFACTS
+
+deployment:
+  publish:
+    branch: master
+    commands:
+      - git config user.name "Tatsuya Kawano (CircleCI)"
+      - git config user.email "tatsuya@hibaridb.org"
+      - ./tools/circleci/push-to-master.sh
+      # Do not publish 1.9 to gh-pages until all (or most of) the contents
+      # are updated from 1.6.
+      - rm -rf public/1.9
+      - ./tools/circleci/publish-to-gh-pages.sh

--- a/tools/circleci/publish-to-gh-pages.sh
+++ b/tools/circleci/publish-to-gh-pages.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This script publishes the contents of `./public` directory of
+# the `master` branch to `origin/gh-pages` branch.
+#
+# Requirements:
+# - CI must be configured with write access to the git remote `origin`.
+# - The current directory must be the top directory of the CircleCI
+#   project.
+# - The current git branch must be `master` branch. (See circle.yml's
+#   deployment -> branch)
+
+set -e
+
+# Get the revision of this branch (master branch)
+REVISION=$(git rev-parse --short HEAD)
+
+# Recreate the worktree for gh-pages
+rm -rf ./gh-pages || true
+git worktree prune || true
+git branch -D gh-pages || true
+mkdir -p ./gh-pages
+git branch gh-pages origin/gh-pages
+git worktree add ./gh-pages gh-pages
+
+# Copy the contents of public to gh-pages
+cp -rp public/* gh-pages/
+cd gh-pages
+
+# Create circle.yml to disable CI on gh-pages branch.
+cat > circle.yml <<EOF
+general:
+  branches:
+    ignore:
+      - gh-pages
+EOF
+
+# If there are anything to commit, do `git commit` and `git push`
+git add .
+set +e
+ret=$(git status | grep -q 'nothing to commit'; echo $?)
+set -e
+if [ $ret -eq 0 ] ; then
+    echo "Nothing to push to gh-pages."
+else
+    git commit -m "ci: publish pages at ${REVISION}"
+    echo "Pushing to gh-pages..."
+    git push origin gh-pages
+fi

--- a/tools/circleci/publish-to-gh-pages.sh
+++ b/tools/circleci/publish-to-gh-pages.sh
@@ -18,7 +18,7 @@ REVISION=$(git rev-parse --short HEAD)
 # Recreate the worktree for gh-pages
 rm -rf ./gh-pages || true
 git worktree prune || true
-git branch -D gh-pages || true
+git branch -D gh-pages 2> /dev/null || true
 mkdir -p ./gh-pages
 git branch gh-pages origin/gh-pages
 git worktree add ./gh-pages gh-pages

--- a/tools/circleci/push-to-master.sh
+++ b/tools/circleci/push-to-master.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This script pushes the contents of `./public` directory to
+# `origin/master` branch.
+#
+# Requirements:
+# - CI must be configured with write access to the git remote `origin`.
+# - The current directory must be the top directory of the CircleCI
+#   project.
+# - The current git branch must be `master` branch. (See circle.yml's
+#   deployment -> branch)
+
+set -e
+
+# Get the revision of this branch (master branch)
+REVISION=$(git rev-parse --short HEAD)
+
+# If there are anything to commit, do `git commit` and `git push`
+git add public
+set +e
+ret=$(git status | grep -q 'nothing to commit'; echo $?)
+set -e
+if [ $ret -eq 0 ] ; then
+    echo "Nothing to push to master."
+else
+    git commit -m "ci: generate pages at ${REVISION} [ci skip]"
+    echo "Pushing to master."
+    git push origin master
+fi

--- a/tools/circleci/setup-rust.sh
+++ b/tools/circleci/setup-rust.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 
 set -e
-set -u
+
+if [ "x$2" == "x" ]; then
+    cat 1>&2 <<EOF
+
+Error: Missing parameter(s).
+
+Usage: $0 <Rust home dir> <Rust nightly release date>
+EOF
+    exit 1
+fi
 
 RUST_HOME=$1
 RUST_NIGHTLY_RELEASE_DATE=$2


### PR DESCRIPTION
- master ブランチの CI の際に、生成した HTML を自動 push する機能を追加します。
  - master ブランチに対して、public ディレクトリの変更内容を push
  - gh-pages ブランチに対して、master の public ディレクトリの内容を push
  - **ただし、現時点では、1.9 ディレクトリの内容は、実際には1.6のものなので、gh-pages へは push しないようにしています**
- gh-pages ブランチでは CI が走らないようにします。

**fork したリポジトリでのテスト結果**
- CI 結果（Deploymentのフェーズが追加されています）：https://circleci.com/gh/tatsuya6502/the-rust-programming-language-ja/58
- master ブランチの自動コミット：https://github.com/tatsuya6502/the-rust-programming-language-ja/commit/ea54b8220998cd3565d55c6602f8004798fb336a
- gh-pages ブランチの自動コミット：https://github.com/tatsuya6502/the-rust-programming-language-ja/commit/f92039c35220acb38077296978909e9c65127fe5

@KeenS レビューをお願いします。あと、gmail のアドレス（コミットログに載っているアドレス）宛に、CircleCI の invitation を送りましたので、ご確認をお願いします。
