### PR TITLE
"property"の訳

### DIFF
--- a/1.6/ja/book/ownership.md
+++ b/1.6/ja/book/ownership.md
@@ -67,7 +67,7 @@ Rustはそれらの目標をたくさんの「ゼロコスト抽象化」を通�
 <!-- [Variable bindings][bindings] have a property in Rust: they ‘have ownership’ -->
 <!-- of what they’re bound to. This means that when a binding goes out of scope, -->
 <!-- Rust will free the bound resources. For example: -->
-Rustの [変数束縛][bindings] は、束縛されているものの「所有権を持つ」という特性を持ちます。
+Rustでは [変数束縛][bindings] はある特性を持ちます。それは、束縛されているものの「所有権を持つ」ということです。
 これは束縛がスコープから外れるとき、Rustは束縛されているリソースを解放するだろうということを意味します。
 例えばこうです。
 

--- a/1.6/ja/book/ownership.md
+++ b/1.6/ja/book/ownership.md
@@ -67,7 +67,7 @@ Rustはそれらの目標をたくさんの「ゼロコスト抽象化」を通�
 <!-- [Variable bindings][bindings] have a property in Rust: they ‘have ownership’ -->
 <!-- of what they’re bound to. This means that when a binding goes out of scope, -->
 <!-- Rust will free the bound resources. For example: -->
-Rustでは [変数束縛][bindings] は所有物を持ちます。つまり、それらはそれらが束縛されているものの「所有権を持つ」ということです。
+Rustの [変数束縛][bindings] は、束縛されているものの「所有権を持つ」という特性を持ちます。
 これは束縛がスコープから外れるとき、Rustは束縛されているリソースを解放するだろうということを意味します。
 例えばこうです。
 

--- a/1.6/ja/book/references-and-borrowing.md
+++ b/1.6/ja/book/references-and-borrowing.md
@@ -410,7 +410,7 @@ Rustはこれが真であることを保証するために、参照のスコー�
 
 <!-- If Rust didn’t check this property, we could accidentally use a reference -->
 <!-- which was invalid. For example: -->
-もしRustがこの所有物をチェックしなければ、無効な参照をうっかり使ってしまうかもしれません。
+もしRustがこの性質をチェックしなければ、無効な参照をうっかり使ってしまうかもしれません。
 例えばこうです。
 
 ```rust,ignore

--- a/1.9/ja/book/ownership.md
+++ b/1.9/ja/book/ownership.md
@@ -67,7 +67,7 @@ Rustはそれらの目標をたくさんの「ゼロコスト抽象化」を通�
 <!-- [Variable bindings][bindings] have a property in Rust: they ‘have ownership’ -->
 <!-- of what they’re bound to. This means that when a binding goes out of scope, -->
 <!-- Rust will free the bound resources. For example: -->
-Rustの [変数束縛][bindings] は、束縛されているものの「所有権を持つ」という特性を持ちます。
+Rustでは [変数束縛][bindings] はある特性を持ちます。それは、束縛されているものの「所有権を持つ」ということです。
 これは束縛がスコープから外れるとき、Rustは束縛されているリソースを解放するだろうということを意味します。
 例えばこうです。
 

--- a/1.9/ja/book/ownership.md
+++ b/1.9/ja/book/ownership.md
@@ -67,7 +67,7 @@ Rustはそれらの目標をたくさんの「ゼロコスト抽象化」を通�
 <!-- [Variable bindings][bindings] have a property in Rust: they ‘have ownership’ -->
 <!-- of what they’re bound to. This means that when a binding goes out of scope, -->
 <!-- Rust will free the bound resources. For example: -->
-Rustでは [変数束縛][bindings] は所有物を持ちます。つまり、それらはそれらが束縛されているものの「所有権を持つ」ということです。
+Rustの [変数束縛][bindings] は、束縛されているものの「所有権を持つ」という特性を持ちます。
 これは束縛がスコープから外れるとき、Rustは束縛されているリソースを解放するだろうということを意味します。
 例えばこうです。
 

--- a/1.9/ja/book/references-and-borrowing.md
+++ b/1.9/ja/book/references-and-borrowing.md
@@ -410,7 +410,7 @@ Rustはこれが真であることを保証するために、参照のスコー�
 
 <!-- If Rust didn’t check this property, we could accidentally use a reference -->
 <!-- which was invalid. For example: -->
-もしRustがこの所有物をチェックしなければ、無効な参照をうっかり使ってしまうかもしれません。
+もしRustがこの性質をチェックしなければ、無効な参照をうっかり使ってしまうかもしれません。
 例えばこうです。
 
 ```rust,ignore


### PR DESCRIPTION
読んでいて若干気になったので訳を見直してみました。

"property"という語に「所有物」という訳を当てている箇所がありますが、文脈から考えると「特性」「性質」のような訳の方が自然に感じました。いかがでしょうか？

また、修正の方針が分からず /1.6 と /1.9 の両方に手を加えていますが、問題あればご指摘下さい。
