### PR TITLE
rustbook の "update-playpenjs" ブランチを使うよう circle.yml を変更する

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
     RUST_NIGHTLY_RELEASE_DATE: "2016-06-01"
     RUST_HOME: $HOME/rust/nightly-$RUST_NIGHTLY_RELEASE_DATE
     RUSTBOOK_GIT_URL: https://github.com/tatsuya6502/rustbook.git
-    RUSTBOOK_GIT_BRANCH: rust-1.11.0-nightly
+    RUSTBOOK_GIT_BRANCH: update-playpenjs
     PATH: $RUST_HOME/bin:$PATH
     LD_LIBRARY_PATH: $RUST_HOME/lib
 


### PR DESCRIPTION
#158 （Rust コードに「Run」ボタンが表示されない）の原因となった rustbook crate の問題を rustbook 側で修正しました。修正版を使うために、circle.yml 内で指定している rustbook git レポジトリのブランチ名を修正します。

なお、rustbook を再インストールするために、CircleCI のキャッシュをクリアする必要があります。本 PR のマージ後に、Circle CI の UI からキャッシュのクリアを行います（[参考](https://circleci.com/docs/how-cache-works/#clearing-the-cache)）
