### PR TITLE
Prevent the error in "cargo install rustbook" on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ dependencies:
     - ./tools/circleci/setup-rust.sh $RUST_HOME $RUST_NIGHTLY_RELEASE_DATE
     - rustc --version --verbose
     - cargo --version --verbose
-    # Install rustbook, or use cached one.
+    # Install rustbook.
     - cargo install --force --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH
     - rustbook help
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,8 @@ machine:
   environment:
     RUST_NIGHTLY_RELEASE_DATE: "2016-06-01"
     RUST_HOME: $HOME/rust/nightly-$RUST_NIGHTLY_RELEASE_DATE
-    RUSTBOOK_GIT_URL: https://github.com/tatsuya6502/rustbook.git
-    RUSTBOOK_GIT_BRANCH: update-playpenjs
+    RUSTBOOK_GIT_URL: https://github.com/rust-lang-ja/rustbook.git
+    RUSTBOOK_GIT_BRANCH: master
     PATH: $RUST_HOME/bin:$PATH
     LD_LIBRARY_PATH: $RUST_HOME/lib
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,11 @@ dependencies:
   post:
     - sudo apt-get update
     - sudo apt-get install curl file gcc git make openssh-client
+    # Delete .gitconfig to prevent "cargo install" and "cargo build" from
+    # failing when pulling the registry info (crates.io-index).
+    # See https://github.com/rust-lang-ja/rust-by-example-ja/issues/38#issuecomment-238214915
+    # NOTE: Assuming .gitconfig only has a rewrite rule for https://github.com
+    - cat $HOME/.gitconfig; rm $HOME/.gitconfig
     - mkdir -p $HOME/rust
     # Install rustc and cargo, or use cached ones.
     - ./tools/circleci/setup-rust.sh $RUST_HOME $RUST_NIGHTLY_RELEASE_DATE

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ dependencies:
     - rustc --version --verbose
     - cargo --version --verbose
     # Install rustbook, or use cached one.
-    - cargo install --force --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH || true
+    - cargo install --force --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH
     - rustbook help
   cache_directories:
     - "~/rust"

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ dependencies:
     - rustc --version --verbose
     - cargo --version --verbose
     # Install rustbook, or use cached one.
-    - cargo install --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH || true
+    - cargo install --force --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH || true
     - rustbook help
   cache_directories:
     - "~/rust"


### PR DESCRIPTION
Circle CI で rustbook に関連する以下の問題を解決します。
1. `cargo install rustbook` で malformed URL エラーが起こらないように `$HOME/.gitconfig` を削除する。
   - エラーの内容
     
     ```
     $ cargo install --root $RUST_HOME --git $RUSTBOOK_GIT_URL --branch $RUSTBOOK_GIT_BRANCH || true
        Updating git repository `https://github.com/tatsuya6502/rustbook.git`
     warning: spurious network error (2 tries remaining): [12/-12] Malformed URL 'ssh://git@github.com:/tatsuya6502/rustbook.git'
     ```
   - 根本的な原因は Cargo が使用している libgit2 が、`ssh://git@github.com:/` という URL に対応していないためと思われる。この URL は、最近 Circle CI の box に追加された `$HOME/.gitconfig` の URL リライトルールで生成されている。
     
     ``` .gitconfig
     [url "ssh://git@github.com:"]
        insteadOf = https://github.com
     ```
   - 暫定的な対応として、`$HOME/.gitconfig` を削除する。
   - 関連する issue コメント：
     [the-rust-programming-language-ja/pull/198](https://github.com/rust-lang-ja/the-rust-programming-language-ja/pull/198#issuecomment-239135537), 
     [rust-by-example-ja/issues/38](https://github.com/rust-lang-ja/rust-by-example-ja/issues/38#issuecomment-238214915)
2. rustbook のリポジトリ URL をアップデート
   - rustbook は以前 tatsuya6502 アカウント配下にあったが、[rust-lang-ja アカウントに所有者を移転した](https://github.com/rust-lang-ja/the-rust-programming-language-ja/issues/9#issuecomment-226922879)。現在の URL から取得するよう circle.yml を修正。
3. 常に最新版の rustbook が使われるよう、`cargo install rustbook` に `--force` オプションを追加。
