### PR TITLE
Fix some typos

### DIFF
--- a/1.9/ja/book/documentation.md
+++ b/1.9/ja/book/documentation.md
@@ -413,7 +413,7 @@ println!("{}", x + y);
 ```text
     まず、`x`に5をセットする
 
-    ```text
+    ```rust
     let x = 5;
     # let y = 6;
     # println!("{}", x + y);
@@ -421,7 +421,7 @@ println!("{}", x + y);
 
     次に、`y`に6をセットする
 
-    ```text
+    ```rust
     # let x = 5;
     let y = 6;
     # println!("{}", x + y);
@@ -429,7 +429,7 @@ println!("{}", x + y);
 
     最後に、`x`と`y`との合計を出力する
 
-    ```text
+    ```rust
     # let x = 5;
     # let y = 6;
     println!("{}", x + y);


### PR DESCRIPTION
すいません、ちょっと出遅れました。細かいPR立て続けにすいません。

なお、この修正に関しては気になる点が幾つかあって
- 今回の修正は本家のミスで、1.6ではミスってるけれど1.9では直ってる
- こちらも本家のミスで、should_panic/ignore/no_runなどのアトリビュートをコードブロックに足す際、そのまま書くとRustのコードブロックだと一般のレンダーで判定されないという問題がありrust注釈が追加されているみたいです(https://github.com/rust-lang/rust/commit/c9517189d7f0e851347859e437fc796411008e66)

とりあえず、本家の1.9で修正されていたものについてはリクエストを出しました。
