### PR TITLE
Fix typo in error-handling.md

### DIFF
--- a/1.6/ja/book/error-handling.md
+++ b/1.6/ja/book/error-handling.md
@@ -845,8 +845,8 @@ fn double_number(number_str: &str) -> Result<i32> {
 <!-- However, `unwrap` can still be used judiciously. What exactly justifies use of -->
 <!-- `unwrap` is somewhat of a grey area and reasonable people can disagree. I'll -->
 <!-- summarize some of my *opinions* on the matter. -->
-しかしながら `unwrap` を使うのが懸命なこともあります。
-どんな場合が `unwrap` の使用を正当化できるのかについては、グレーな部分があり、人によって意見が分かれます。
+しかしながら `unwrap` を使うのが賢明なこともあります。
+どんな場合に `unwrap` の使用を正当化できるのかについては、グレーな部分があり、人によって意見が分かれます。
 ここで、この問題についての、私の *個人的な意見* をまとめたいと思います。
 
 <!-- * **In examples and quick 'n' dirty code.** Sometimes you're writing examples -->

--- a/1.9/ja/book/error-handling.md
+++ b/1.9/ja/book/error-handling.md
@@ -877,8 +877,8 @@ fn double_number(number_str: &str) -> Result<i32> {
 <!-- However, `unwrap` can still be used judiciously. What exactly justifies use of -->
 <!-- `unwrap` is somewhat of a grey area and reasonable people can disagree. I'll -->
 <!-- summarize some of my *opinions* on the matter. -->
-しかしながら `unwrap` を使うのが懸命なこともあります。
-どんな場合が `unwrap` の使用を正当化できるのかについては、グレーな部分があり、人によって意見が分かれます。
+しかしながら `unwrap` を使うのが賢明なこともあります。
+どんな場合に `unwrap` の使用を正当化できるのかについては、グレーな部分があり、人によって意見が分かれます。
 ここで、この問題についての、私の *個人的な意見* をまとめたいと思います。
 
 <!-- * **In examples and quick 'n' dirty code.** Sometimes you're writing examples -->


### PR DESCRIPTION
誤字の訂正(懸命 -> 賢明)
「どんな場合が」は「どんな場合に」の方が自然な日本語になると思います。(英語とは少しずれますが…)