### PR TITLE
morph の説明を「様相」から単なる「相」へ

### DIFF
--- a/1.6/ja/book/generics.md
+++ b/1.6/ja/book/generics.md
@@ -6,7 +6,7 @@ multiple types of arguments. In Rust, we can do this with generics.
 Generics are called ‘parametric polymorphism’ in type theory,
 which means that they are types or functions that have multiple forms (‘poly’
 is multiple, ‘morph’ is form) over a given parameter (‘parametric’). -->
-時々、関数やデータ型を書いていると、引数が複数の型に対応したものが欲しくなることもあります。Rustでは、ジェネリクスを用いてこれを実現しています。ジェネリクスは型理論において「パラメトリック多相」(parametric polymorphism)と呼ばれ、与えられたパラメータにより(「parametric」)型もしくは関数が多数の様相(「poly」は多様、「morph」は様相を意味します)(訳注: ここで「様相」は型を指します)を持つことを意味しています。
+時々、関数やデータ型を書いていると、引数が複数の型に対応したものが欲しくなることもあります。Rustでは、ジェネリクスを用いてこれを実現しています。ジェネリクスは型理論において「パラメトリック多相」(parametric polymorphism)と呼ばれ、与えられたパラメータにより(「parametric」)型もしくは関数が多くの相（「poly」は「多くの」、「morph」は「相（かたち）」を意味します）（訳注: ここで「相」は型を指します）を持つことを意味しています。
 
 <!-- Anyway, enough type theory, let’s check out some generic code. Rust’s
 standard library provides a type, `Option<T>`, that’s generic: -->

--- a/1.6/ja/book/traits.md
+++ b/1.6/ja/book/traits.md
@@ -318,7 +318,7 @@ not, because neither the trait nor the type are in our code. -->
 <!-- One last thing about traits: generic functions with a trait bound use
 ‘monomorphization’ (mono: one, morph: form), so they are statically dispatched.
 What’s that mean? Check out the chapter on [trait objects][to] for more details. -->
-トレイトに関して最後に1つ。トレイト境界が設定されたジェネリック関数は「単相化」(monomorphization)(mono:単一の、morph:様相)されるため、静的ディスパッチが行われます。一体どういう意味でしょうか？詳細については、 [トレイトオブジェクト][to] の章をチェックしてください。
+トレイトに関して最後に1つ。トレイト境界が設定されたジェネリック関数は「単相化」(monomorphization)（mono: 単一の、morph: 相）されるため、静的ディスパッチが行われます。一体どういう意味でしょうか？詳細については、 [トレイトオブジェクト][to] の章をチェックしてください。
 
 [to]: trait-objects.html
 

--- a/1.9/ja/book/generics.md
+++ b/1.9/ja/book/generics.md
@@ -8,8 +8,8 @@
 <!-- is multiple, ‘morph’ is form) over a given parameter (‘parametric’). -->
 時々、関数やデータ型を書いていると、引数が複数の型に対応したものが欲しくなることもあります。
 Rustでは、ジェネリクスを用いてこれを実現しています。
-ジェネリクスは型理論において「パラメトリック多相」(parametric polymorphism)と呼ばれ、与えられたパラメータにより(「parametric」)型もしくは関数が多数の様相(「poly」は多様、「morph」は様相を意味します)
-(訳注: ここで「様相」は型を指します)を持つことを意味しています。
+ジェネリクスは型理論において「パラメトリック多相」(parametric polymorphism)と呼ばれ、与えられたパラメータにより(「parametric」)型もしくは関数が多くの相（「poly」は「多くの」、「morph」は「相（かたち）」を意味します）
+（訳注: ここで「相」は型を指します）を持つことを意味しています。
 
 <!-- Anyway, enough type theory, let’s check out some generic code. Rust’s -->
 <!-- standard library provides a type, `Option<T>`, that’s generic: -->

--- a/1.9/ja/book/traits.md
+++ b/1.9/ja/book/traits.md
@@ -324,7 +324,7 @@ the type are defined in our crate. -->
 <!-- One last thing about traits: generic functions with a trait bound use
 ‘monomorphization’ (mono: one, morph: form), so they are statically dispatched.
 What’s that mean? Check out the chapter on [trait objects][to] for more details. -->
-トレイトに関して最後に1つ。トレイト境界が設定されたジェネリック関数は「単相化」(monomorphization)(mono:単一の、morph:様相)されるため、静的ディスパッチが行われます。一体どういう意味でしょうか？詳細については、 [トレイトオブジェクト][to] の章をチェックしてください。
+トレイトに関して最後に1つ。トレイト境界が設定されたジェネリック関数は「単相化」(monomorphization)（mono: 単一の、morph: 相）されるため、静的ディスパッチが行われます。一体どういう意味でしょうか？詳細については、 [トレイトオブジェクト][to] の章をチェックしてください。
 
 [cm]: crates-and-modules.html
 [to]: trait-objects.html


### PR DESCRIPTION
多相（polymorphism）や単相（monomorphism）の morph の説明で様相という言葉を使っていますが、型まわりで様相という語をつかうと、様相型システム（modal type system）等の様相（modality）とまぎらわしいので、単に「相」とした方がよいと思います（「相」といっただけで意味が通じるか不安だったので括弧書きで説明をつけていますが、なくてもよいかもしれません）。

参考までに『型システム入門』では「**poly** = many = 多、**morph** = form = 相」（p.267, 23.2 さまざまな多相性）のような説明をしています。

強いて二字の語を選ぶなら「形相（けいそう）」などがあたるのではないかと思います。