### PR TITLE
fix strings.md

### DIFF
--- a/1.6/ja/book/strings.md
+++ b/1.6/ja/book/strings.md
@@ -6,27 +6,27 @@
 <!-- focus. Any time you have a data structure of variable size, things can get -->
 <!-- tricky, and strings are a re-sizable data structure. That being said, Rust’s -->
 <!-- strings also work differently than in some other systems languages, such as C. -->
-文字列は、プログラマがマスタすべき重要なコンセプトです。
-Rustの文字列の扱いは、Rust言語がシステムにフォーカスしているため、少し他の言語と異なります。
-動的なサイズを持つデータ構造が有る時、常に物事は複雑になります。
+文字列は、プログラマがマスタすべき重要な概念です。
+Rustの文字列の扱いは、Rust言語がシステムプログラミングにフォーカスしているため、少し他の言語と異なります。
+動的なサイズを持つデータ構造があるといつも、物事は複雑性を孕みます。
 そして文字列もまたサイズを変更することができるデータ構造です。
-これはつまり、Rustの文字列もまた、Cのような他のシステム言語とは少し異なるということです。
+これはつまり、Rustの文字列もまた、Cのような他のシステム言語とは少し異なる振る舞いをするということです。
 
 
 <!-- Let’s dig into the details. A ‘string’ is a sequence of Unicode scalar values -->
 <!-- encoded as a stream of UTF-8 bytes. All strings are guaranteed to be a valid -->
 <!-- encoding of UTF-8 sequences. Additionally, unlike some systems languages, -->
 <!-- strings are not null-terminated and can contain null bytes. -->
-詳しく見ていきましょう、 「文字列」は、UTF-8のバイトストリームとしてエンコードされたユニコードのスカラ値のシーケンスです。
-すべての文字列は、正しくエンコードされたUTF-8のシーケンスであることが保証されています。
-また、他のシステム言語とはことなり、文字列はnull終端でなく、nullバイトを含むことが可能です。
+詳しく見ていきましょう。「文字列」は、UTF-8のバイトストリームとしてエンコードされたユニコードのスカラ値のシーケンスです。
+すべての文字列は、妥当なUTF-8のシーケンスであることが保証されています。
+また、他のシステム言語とは異なり、文字列はnull終端でなく、nullバイトを保持することもできます。
 
 <!-- Rust has two main types of strings: `&str` and `String`. Let’s talk about -->
 <!-- `&str` first. These are called ‘string slices’. A string slice has a fixed -->
 <!-- size, and cannot be mutated. It is a reference to a sequence of UTF-8 bytes. -->
-Rustは主要な文字列型を二種類持っています: `&str` と `String`です。
-まず `&str` について説明しましょう。 `&str` は「文字列のスライス」と呼ばれます。
-文字列のスライスは固定のサイズを持ち、変更不可能です。そして、文字列のスライスはUTF-8のバイトシーケンスへの参照です。
+Rustには主要な文字列型が二種類あります。`&str` と `String`です。
+まず `&str` について説明しましょう。 `&str` は「文字列スライス」と呼ばれます。
+文字列スライスは固定サイズで変更不可能です。文字列スライスはUTF-8のバイトシーケンスへの参照です。
 
 
 ```rust
@@ -38,16 +38,17 @@ let greeting = "Hello there."; // greeting: &'static str
 <!-- inside our compiled program, and exists for the entire duration it runs. The -->
 <!-- `greeting` binding is a reference to this statically allocated string. Any -->
 <!-- function expecting a string slice will also accept a string literal. -->
-`"Hello there."` は文字列リテラルであり、 `&'static str` 型を持ちます。
-文字列リテラルは、静的にアロケートされた文字列のスライスであり、これはつまりコンパイルされたプログラム中に保存されており、
-プログラムの実行中全てにわたって存在していることを意味しています。
-どの文字列のスライスを引数として期待している関数も、文字列リテラルを引数に取ることができます。
+`"Hello there."` は文字列リテラルで、 `&'static str` 型を持ちます。
+文字列リテラルは、静的にアロケートされた文字列スライスです。これはつまりコンパイルされたプログラム内に保存されていて、
+プログラムの実行中全てにわたって存在しているということです。
+`greeting`の束縛はこのように静的にアロケートされた文字列を参照しています。
+文字列スライスを引数として期待している関数はすべて文字列リテラルを引数に取ることができます。
 
 <!-- String literals can span multiple lines. There are two forms. The first will -->
 <!-- include the newline and the leading spaces: -->
-文字列リテラルは複数行に渡ることができます。
-複数行の文字列リテラルを記述する方法は、2つの形式があります。
-一つ目の形式は、改行と行頭の空白を文字列に含む形式です:
+文字列リテラルは複数行にわたることができます。
+複数行文字列リテラルには2つの形式があります。
+一つ目の形式は、改行と行頭の空白を含む形式です:
 
 ```rust
 let s = "foo
@@ -57,7 +58,7 @@ assert_eq!("foo\n        bar", s);
 ```
 
 <!-- The second, with a `\`, trims the spaces and the newline: -->
-もう一つは `\` を用いて、空白と改行を削る形式です:
+もう一つは `\` を使って空白と改行を削る形式です:
 
 ```rust
 let s = "foo\
@@ -70,9 +71,9 @@ assert_eq!("foobar", s);
 <!-- This string is growable, and is also guaranteed to be UTF-8. `String`s are -->
 <!-- commonly created by converting from a string slice using the `to_string` -->
 <!-- method. -->
-Rustは `&str` だけでなく、 `String` というヒープにアロケートされる文字列の形式も持っています。
-この文字列は伸張可能であり、またUTF-8であることが保証されています。
-`String` は一般的に文字列のスライスをメソッド `to_string` を用いて変換することで生成されます。
+Rustには `&str` だけでなく、 `String` というヒープアロケートされる文字列もあります。
+この文字列は伸張可能であり、またUTF-8であることも保証されています。
+`String` は一般的に文字列スライスを `to_string` メソッドで変換することで作成されます。
 
 ```rust
 let mut s = "Hello".to_string(); // mut s: String
@@ -100,9 +101,9 @@ fn main() {
 <!-- instead of `&str`. For example, [`TcpStream::connect`][connect] has a parameter -->
 <!-- of type `ToSocketAddrs`. A `&str` is okay but a `String` must be explicitly -->
 <!-- converted using `&*`. -->
-このような変換は `&str` の代わりに、 `&str` のトレイトを引数として期待している関数では自動的には行われません。
+このような変換は `&str` ではなく `&str` の実装するトレイトを引数として取る関数に対しては自動的には行われません。
 たとえば、 [`TcpStream::connect`][connect] は引数として型 `ToSocketAddrs` を要求しています。
-このような関数には `&str` は渡せますが、 `String` は `&*` を用いて明示的に変換する必要があります。
+このような関数には `&str` は渡せますが、 `String` は `&*` を用いて明示的に変換しなければなりません。
 
 ```rust,no_run
 use std::net::TcpStream;
@@ -117,14 +118,14 @@ TcpStream::connect(&*addr_string); // addr_string を &str に変換して渡す
 
 <!-- Viewing a `String` as a `&str` is cheap, but converting the `&str` to a -->
 <!-- `String` involves allocating memory. No reason to do that unless you have to! -->
-`String` を `&str` として見るコストは低いですが、`&str` を `String` に変換するのはメモリのアロケーションを発生させます。
-必要がなければ、やるべきではないでしょう!
+`String` を `&str` として見るコストは低いのですが、`&str` を `String` に変換するとメモリアロケーションが発生します。
+必要がなければ、やるべきではないでしょう！
 
 <!-- ## Indexing  -->
 ## インデクシング
 
 <!-- Because strings are valid UTF-8, strings do not support indexing: -->
-文字列が正しいUTF-8であるため、文字列はインデクシングをサポートしていません:
+文字列は妥当なUTF-8であるため、文字列はインデクシングをサポートしていません:
 
 ```rust,ignore
 let s = "hello";
@@ -140,11 +141,11 @@ println!("The first letter of s is {}", s[0]); // エラー!!!
 <!-- isn’t something defined in Unicode, exactly. We can choose to look at a string as -->
 <!-- individual bytes, or as codepoints:-->
 普通、ベクタへの `[]` を用いたアクセスはとても高速です。
-しかし、UTF-8にエンコードされた文字列中の一つ一つの文字は複数のバイトであることが可能なため、
-文字列のn番の文字を探すためには文字列上を移動していく必要があります。
-そのような作業はとても高コストな演算であり、誤解してはならない点です。
-さらに言えば、「文字」というものはUnicodeにおいては正確に定義されていません。
-文字列を、それぞれのバイトとして見ることも、コードポイントの集まりとして見ることもできるのです。
+しかし、UTF-8でエンコードされた文字列内の文字は複数のバイト対応することがあるため、
+文字列のn番目の文字を探すには文字列上を走査していく必要があります。
+そのような処理はベクタのアクセスに比べると非常に高コストな演算であり、誤解を招きたくなかったのです。
+さらに言えば、上の「文字 (letter)」というのはUnicodeでの定義と厳密には一致しません。
+文字列をバイト列として見るかコードポイント列として見るか選ぶことができます。
 
 ```rust
 let hachiko = "忠犬ハチ公";
@@ -182,12 +183,12 @@ let dog = hachiko.chars().nth(1); // hachiko[1]のような感じで
 ```
 
 <!-- This emphasizes that we have to walk from the beginning of the list of `chars`. -->
-このコードは、`chars` のリストの上を移動している事を強調しています。
+このコードは、`chars` のリストの上を先頭から走査しなければならないことを強調しています。
 
 ## スライシング
 
 <!-- You can get a slice of a string with slicing syntax: -->
-文字列のスライスは以下のようにスライス構文を用いて取得することができます:
+文字列スライスは以下のようにスライス構文を使って取得することができます:
 
 ```rust
 let dog = "hachiko";
@@ -214,10 +215,10 @@ character boundary'
 ```
 
 <!-- ## Concatenation -->
-## 結合
+## 連結
 
 <!-- If you have a `String`, you can concatenate a `&str` to the end of it: -->
-`String` が存在するとき、 `&str` を末尾に結合することができます:
+`String` が存在するとき、 `&str` を末尾に連結することができます:
 
 ```rust
 let hello = "Hello ".to_string();
@@ -227,7 +228,7 @@ let hello_world = hello + world;
 ```
 
 <!-- But if you have two `String`s, you need an `&`: -->
-しかし、２つの `String` を結合するには、 `&` が必要になります:
+しかし、2つの `String` を連結するには、 `&` が必要になります:
 
 ```rust
 let hello = "Hello ".to_string();
@@ -239,7 +240,7 @@ let hello_world = hello + &world;
 <!-- This is because `&String` can automatically coerce to a `&str`. This is a -->
 <!-- feature called ‘[`Deref` coercions][dc]’. -->
 これは、 `&String` が自動的に `&str` に型強制されるためです。
-このフィーチャーは 「 [`Deref` による型強制][dc] 」と呼ばれています。
+このフィーチャは 「 [`Deref` による型強制][dc] 」と呼ばれています。
 
 [dc]: deref-coercions.html
 [connect]: ../std/net/struct.TcpStream.html#method.connect

--- a/1.9/ja/book/strings.md
+++ b/1.9/ja/book/strings.md
@@ -6,27 +6,27 @@
 <!-- focus. Any time you have a data structure of variable size, things can get -->
 <!-- tricky, and strings are a re-sizable data structure. That being said, Rust’s -->
 <!-- strings also work differently than in some other systems languages, such as C. -->
-文字列は、プログラマがマスタすべき重要なコンセプトです。
-Rustの文字列の扱いは、Rust言語がシステムにフォーカスしているため、少し他の言語と異なります。
-動的なサイズを持つデータ構造が有る時、常に物事は複雑になります。
+文字列は、プログラマがマスタすべき重要な概念です。
+Rustの文字列の扱いは、Rust言語がシステムプログラミングにフォーカスしているため、少し他の言語と異なります。
+動的なサイズを持つデータ構造があるといつも、物事は複雑性を孕みます。
 そして文字列もまたサイズを変更することができるデータ構造です。
-これはつまり、Rustの文字列もまた、Cのような他のシステム言語とは少し異なるということです。
+これはつまり、Rustの文字列もまた、Cのような他のシステム言語とは少し異なる振る舞いをするということです。
 
 
 <!-- Let’s dig into the details. A ‘string’ is a sequence of Unicode scalar values -->
 <!-- encoded as a stream of UTF-8 bytes. All strings are guaranteed to be a valid -->
 <!-- encoding of UTF-8 sequences. Additionally, unlike some systems languages, -->
 <!-- strings are not null-terminated and can contain null bytes. -->
-詳しく見ていきましょう、 「文字列」は、UTF-8のバイトストリームとしてエンコードされたユニコードのスカラ値のシーケンスです。
-すべての文字列は、正しくエンコードされたUTF-8のシーケンスであることが保証されています。
-また、他のシステム言語とはことなり、文字列はnull終端でなく、nullバイトを含むことが可能です。
+詳しく見ていきましょう。「文字列」は、UTF-8のバイトストリームとしてエンコードされたユニコードのスカラ値のシーケンスです。
+すべての文字列は、妥当なUTF-8のシーケンスであることが保証されています。
+また、他のシステム言語とは異なり、文字列はnull終端でなく、nullバイトを保持することもできます。
 
 <!-- Rust has two main types of strings: `&str` and `String`. Let’s talk about -->
 <!-- `&str` first. These are called ‘string slices’. A string slice has a fixed -->
 <!-- size, and cannot be mutated. It is a reference to a sequence of UTF-8 bytes. -->
-Rustは主要な文字列型を二種類持っています: `&str` と `String`です。
-まず `&str` について説明しましょう。 `&str` は「文字列のスライス」と呼ばれます。
-文字列のスライスは固定のサイズを持ち、変更不可能です。そして、文字列のスライスはUTF-8のバイトシーケンスへの参照です。
+Rustには主要な文字列型が二種類あります。`&str` と `String`です。
+まず `&str` について説明しましょう。 `&str` は「文字列スライス」と呼ばれます。
+文字列スライスは固定サイズで変更不可能です。文字列スライスはUTF-8のバイトシーケンスへの参照です。
 
 
 ```rust
@@ -38,16 +38,17 @@ let greeting = "Hello there."; // greeting: &'static str
 <!-- inside our compiled program, and exists for the entire duration it runs. The -->
 <!-- `greeting` binding is a reference to this statically allocated string. Any -->
 <!-- function expecting a string slice will also accept a string literal. -->
-`"Hello there."` は文字列リテラルであり、 `&'static str` 型を持ちます。
-文字列リテラルは、静的にアロケートされた文字列のスライスであり、これはつまりコンパイルされたプログラム中に保存されており、
-プログラムの実行中全てにわたって存在していることを意味しています。
-どの文字列のスライスを引数として期待している関数も、文字列リテラルを引数に取ることができます。
+`"Hello there."` は文字列リテラルで、 `&'static str` 型を持ちます。
+文字列リテラルは、静的にアロケートされた文字列スライスです。これはつまりコンパイルされたプログラム内に保存されていて、
+プログラムの実行中全てにわたって存在しているということです。
+`greeting`の束縛はこのように静的にアロケートされた文字列を参照しています。
+文字列スライスを引数として期待している関数はすべて文字列リテラルを引数に取ることができます。
 
 <!-- String literals can span multiple lines. There are two forms. The first will -->
 <!-- include the newline and the leading spaces: -->
-文字列リテラルは複数行に渡ることができます。
-複数行の文字列リテラルを記述する方法は、2つの形式があります。
-一つ目の形式は、改行と行頭の空白を文字列に含む形式です:
+文字列リテラルは複数行にわたることができます。
+複数行文字列リテラルには2つの形式があります。
+一つ目の形式は、改行と行頭の空白を含む形式です:
 
 ```rust
 let s = "foo
@@ -57,7 +58,7 @@ assert_eq!("foo\n        bar", s);
 ```
 
 <!-- The second, with a `\`, trims the spaces and the newline: -->
-もう一つは `\` を用いて、空白と改行を削る形式です:
+もう一つは `\` を使って空白と改行を削る形式です:
 
 ```rust
 let s = "foo\
@@ -70,17 +71,17 @@ assert_eq!("foobar", s);
 <!-- reference. This is because `str` is an unsized type which requires additional -->
 <!-- runtime information to be usable. For more information see the chapter on -->
 <!-- [unsized types][ut]. -->
-通常、`str` には直接アクセス出来ず、 `&str` 参照を通してのみアクセス出来ることに注意して下さい。
-これは `str` がサイズ不定型であり追加の実行時情報がないと利用出来ないからです。
+通常、`str` には直接アクセスできず、 `&str` 経由でのみアクセス出来ることに注意して下さい。
+これは `str` がサイズ不定型であり追加の実行時情報がないと使用できないからです。
 詳しくは[サイズ不定型][ut]の章を読んで下さい。
 
 <!-- Rust has more than only `&str`s though. A `String` is a heap-allocated string. -->
 <!-- This string is growable, and is also guaranteed to be UTF-8. `String`s are -->
 <!-- commonly created by converting from a string slice using the `to_string` -->
 <!-- method. -->
-Rustは `&str` だけでなく、 `String` というヒープにアロケートされる文字列の形式も持っています。
-この文字列は伸張可能であり、またUTF-8であることが保証されています。
-`String` は一般的に文字列のスライスをメソッド `to_string` を用いて変換することで生成されます。
+Rustには `&str` だけでなく、 `String` というヒープアロケートされる文字列もあります。
+この文字列は伸張可能であり、またUTF-8であることも保証されています。
+`String` は一般的に文字列スライスを `to_string` メソッドで変換することで作成されます。
 
 ```rust
 let mut s = "Hello".to_string(); // mut s: String
@@ -108,9 +109,9 @@ fn main() {
 <!-- instead of `&str`. For example, [`TcpStream::connect`][connect] has a parameter -->
 <!-- of type `ToSocketAddrs`. A `&str` is okay but a `String` must be explicitly -->
 <!-- converted using `&*`. -->
-このような変換は `&str` の代わりに、 `&str` のトレイトを引数として期待している関数では自動的には行われません。
+このような変換は `&str` ではなく `&str` の実装するトレイトを引数として取る関数に対しては自動的には行われません。
 たとえば、 [`TcpStream::connect`][connect] は引数として型 `ToSocketAddrs` を要求しています。
-このような関数には `&str` は渡せますが、 `String` は `&*` を用いて明示的に変換する必要があります。
+このような関数には `&str` は渡せますが、 `String` は `&*` を用いて明示的に変換しなければなりません。
 
 ```rust,no_run
 use std::net::TcpStream;
@@ -125,14 +126,14 @@ TcpStream::connect(&*addr_string); // addr_string を &str に変換して渡す
 
 <!-- Viewing a `String` as a `&str` is cheap, but converting the `&str` to a -->
 <!-- `String` involves allocating memory. No reason to do that unless you have to! -->
-`String` を `&str` として見るコストは低いですが、`&str` を `String` に変換するのはメモリのアロケーションを発生させます。
-必要がなければ、やるべきではないでしょう!
+`String` を `&str` として見るコストは低いのですが、`&str` を `String` に変換するとメモリアロケーションが発生します。
+必要がなければ、やるべきではないでしょう！
 
 <!-- ## Indexing  -->
 ## インデクシング
 
-<!-- Because strings are valid UTF-8, they do not support indexing: -->
-文字列が正しいUTF-8であるため、文字列はインデクシングをサポートしていません:
+<!-- Because strings are valid UTF-8, strings do not support indexing: -->
+文字列は妥当なUTF-8であるため、文字列はインデクシングをサポートしていません:
 
 ```rust,ignore
 let s = "hello";
@@ -148,11 +149,11 @@ println!("The first letter of s is {}", s[0]); // エラー!!!
 <!-- isn’t something defined in Unicode, exactly. We can choose to look at a string as -->
 <!-- individual bytes, or as codepoints:-->
 普通、ベクタへの `[]` を用いたアクセスはとても高速です。
-しかし、UTF-8にエンコードされた文字列中の一つ一つの文字は複数のバイトであることが可能なため、
-文字列のn番の文字を探すためには文字列上を移動していく必要があります。
-そのような作業はとても高コストな演算であり、誤解してはならない点です。
-さらに言えば、「文字」というものはUnicodeにおいては正確に定義されていません。
-文字列を、それぞれのバイトとして見ることも、コードポイントの集まりとして見ることもできるのです。
+しかし、UTF-8でエンコードされた文字列内の文字は複数のバイト対応することがあるため、
+文字列のn番目の文字を探すには文字列上を走査していく必要があります。
+そのような処理はベクタのアクセスに比べると非常に高コストな演算であり、誤解を招きたくなかったのです。
+さらに言えば、上の「文字 (letter)」というのはUnicodeでの定義と厳密には一致しません。
+文字列をバイト列として見るかコードポイント列として見るか選ぶことができます。
 
 ```rust
 let hachiko = "忠犬ハチ公";
@@ -190,12 +191,12 @@ let dog = hachiko.chars().nth(1); // hachiko[1]のような感じで
 ```
 
 <!-- This emphasizes that we have to walk from the beginning of the list of `chars`. -->
-このコードは、`chars` のリストの上を移動している事を強調しています。
+このコードは、`chars` のリストの上を先頭から走査しなければならないことを強調しています。
 
 ## スライシング
 
 <!-- You can get a slice of a string with slicing syntax: -->
-文字列のスライスは以下のようにスライス構文を用いて取得することができます:
+文字列スライスは以下のようにスライス構文を使って取得することができます:
 
 ```rust
 let dog = "hachiko";
@@ -222,10 +223,10 @@ character boundary'
 ```
 
 <!-- ## Concatenation -->
-## 結合
+## 連結
 
 <!-- If you have a `String`, you can concatenate a `&str` to the end of it: -->
-`String` が存在するとき、 `&str` を末尾に結合することができます:
+`String` が存在するとき、 `&str` を末尾に連結することができます:
 
 ```rust
 let hello = "Hello ".to_string();
@@ -235,7 +236,7 @@ let hello_world = hello + world;
 ```
 
 <!-- But if you have two `String`s, you need an `&`: -->
-しかし、２つの `String` を結合するには、 `&` が必要になります:
+しかし、2つの `String` を連結するには、 `&` が必要になります:
 
 ```rust
 let hello = "Hello ".to_string();
@@ -247,7 +248,7 @@ let hello_world = hello + &world;
 <!-- This is because `&String` can automatically coerce to a `&str`. This is a -->
 <!-- feature called ‘[`Deref` coercions][dc]’. -->
 これは、 `&String` が自動的に `&str` に型強制されるためです。
-このフィーチャーは 「 [`Deref` による型強制][dc] 」と呼ばれています。
+このフィーチャは 「 [`Deref` による型強制][dc] 」と呼ばれています。
 
 [ut]: unsized-types.html
 [dc]: deref-coercions.html

--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -180,6 +180,7 @@
 | standard library               | 標準ライブラリ
 | string                         | 文字列
 | string interpolation           | 文字列インターポーレーション
+| string slice                   | 文字列スライス
 | struct                         | 構造体
 | structure                      | ストラクチャ
 | sum type                       | 直和型


### PR DESCRIPTION
* UTF-8 として valid なことを「正しい」と訳すとインデクシングまわりの説明が意味不明になるので「妥当な」としてみました（原文が説明不足な気もしますが）
* string slice は他の部分では「文字列スライス」としているようなので、そちらに統一しました
* Furthermore, ‘letter’ isn’t something defined in Unicode, exactly. が何を言いたいのかよくわからなかったのですが、修正後のような意味でないかと思います。
* その他、訳の抜けていた部分を直したり、てにをはを調整しています。
