### PR TITLE
PDF 生成ジョブ（trpl-ja-pdf）の自動起動

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,4 +66,5 @@ deployment:
       # are updated from 1.6.
       - rm -rf docs/1.9
       - ./tools/circleci/push-to-master.sh
+      - ./tools/circleci/trigger-trpl-pdf-ja.sh
       # - ./tools/circleci/publish-to-gh-pages.sh

--- a/circle.yml
+++ b/circle.yml
@@ -58,13 +58,13 @@ test:
 
 deployment:
   publish:
-    branch: master
+    branch: [master, triggering-trpl-ja-pdf]
     commands:
       - git config user.name "Tatsuya Kawano (CircleCI)"
       - git config user.email "tatsuya@hibaridb.org"
       # Do not publish 1.9 to gh-pages until all (or most of) the contents
       # are updated from 1.6.
       - rm -rf docs/1.9
-      - ./tools/circleci/push-to-master.sh
+      # - ./tools/circleci/push-to-master.sh
       - ./tools/circleci/trigger-trpl-pdf-ja.sh
       # - ./tools/circleci/publish-to-gh-pages.sh

--- a/circle.yml
+++ b/circle.yml
@@ -58,13 +58,13 @@ test:
 
 deployment:
   publish:
-    branch: [master, triggering-trpl-ja-pdf]
+    branch: master
     commands:
       - git config user.name "Tatsuya Kawano (CircleCI)"
       - git config user.email "tatsuya@hibaridb.org"
       # Do not publish 1.9 to gh-pages until all (or most of) the contents
       # are updated from 1.6.
       - rm -rf docs/1.9
-      # - ./tools/circleci/push-to-master.sh
+      - ./tools/circleci/push-to-master.sh
       - ./tools/circleci/trigger-trpl-pdf-ja.sh
       # - ./tools/circleci/publish-to-gh-pages.sh

--- a/tools/circleci/trigger-trpl-pdf-ja.sh
+++ b/tools/circleci/trigger-trpl-pdf-ja.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# This script triggers a Travis CI build on trpl-ja-pdf to generates
+# PDF files of TRPL. It does so by sending a request to Travis's API
+# server.
+#
+# This script referes to the following mandatory and optional
+# environment variables:
+#
+# - TRPL_JA_PDF_TRAVIS_AUTH_TOKEN (Mandatory):
+#     The auth token required by Travis CI web API. Since this
+#     variable carries a sensitive data, it should not be defined in
+#     circle.yml. Instead, it should be defined at Circle CI's web
+#     console at:
+#     https://circleci.com/gh/rust-lang-ja/the-rust-programming-language-ja/edit#env-vars
+#
+#     To obtain a Travis auth token, follow the instructions on:
+#     https://docs.travis-ci.com/user/triggering-builds/
+#
+# - TRPL_JA_PDF_GITHUB_REPO (Optional):
+#     The GitHub repository name of trpl-ja-pdf, default to
+#     `trpl-ja-pdf`. To override it, define this variable at
+#     CircleCI's web console or in circle.yml.
+#
+# - TRPL_JA_PDF_GITHUB_ORG (Optional):
+#     The GitHub organization or user name of trpl-ja-pdf, default to
+#    `rust-lanu-ja`. To override it, define this variable at
+#    CirildCI's web console or in circle.yml.
+
+set -e
+
+if [ -z "${TRPL_JA_PDF_TRAVIS_AUTH_TOKEN+x}" ]; then
+    echo "ERROR: Environment variable TRPL_JA_PDF_TRAVIS_AUTH_TOKEN is undefined."
+    echo "       If you want to trigger a Travis CI build for trpl-ja-pdf,"
+    echo "       please read comments in this script to define the variable."
+    exit 1
+fi
+
+GITHUB_REPO=${TRPL_JA_PDF_GITHUB_REPO:-tarpl-ja-pdf}
+GITHUB_ORG=${TRPL_JA_PDF_GITHUB_ORG:-rust-lang-ja}
+
+set -u
+
+# Get the revision of current branch.
+REVISION=$(git rev-parse --short HEAD)
+
+BUILD_PARAMS='{
+  "request": {
+    "branch": "master"
+    "message": "automatic build triggered by trpl-ja commit ${REVISION}"
+  }
+}'
+
+echo "Triggering a build on Travis CI for ${GITHUB_ORG}/${GITHUB_REPO}."
+
+set +e
+curl -s -X POST \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/json" \
+     -H "Travis-API-Version: 3" \
+     -H "Authorization: token ${TRPL_JA_PDF_TRAVIS_AUTH_TOKEN}" \
+     -d "$BUILD_PARAMS" \
+        https://api.travis-ci.org/repo/${GITHUB_ORG}%2F${GITHUB_REPO}/requests
+RET=$?
+set -e
+
+if [ $RET -eq 0 ]; then
+    echo "Successfully triggered the Travis CI build."
+else
+    echo "Failed to trigger the Travis CI build."
+    exit 1
+fi


### PR DESCRIPTION
#241 PDF版の自動更新 を実現するために、本リポジトリの CircleCI ジョブから、 [trpl-ja-pdf](https://github.com/rust-lang-ja/trpl-ja-pdf) リポジトリの Travis CI ジョブを起動するよう変更します。

以下の仕組みで動作ます。

1. CircleCI ジョブは、master ブランチの RustBook HTML生成後、シェルスクリプト `trigger-trpl-pdf-ja.sh` を実行する。
2. `trigger-trpl-pdf-ja.sh` は Travis CI の V3 API を用いて、trpl-ja-pdf の master ブランチを対象とした Travis CI ビルドを起動する。
3. trpl-ja-pdf の Travis CI ジョブは、本リポジトリの最新版の master を取得し、PDFを生成、triple-ja-pdf の gh-pages ブランチへ push する。

この PR の対象範囲は1と2になります。3は [trpl-ja-pdf PR #6](https://github.com/rust-lang-ja/trpl-ja-pdf/issues/6) でカバーされます。

なお `trigger-trpl-pdf-ja.sh` で使用する環境変数 `TRPL_JA_PDF_TRAVIS_AUTH_TOKEN` （Travis CI API の認証トークン）は、ウェブコンソールの [Environment Variables のページ](https://circleci.com/gh/rust-lang-ja/the-rust-programming-language-ja/edit#env-vars) からすでに設定済みです。

参考：フォークしたリポジトリでの実行結果：
https://circleci.com/gh/tatsuya6502/the-rust-programming-language-ja/183
