### PR TITLE
fix broken link in README.md

### DIFF
--- a/1.6/ja/book/README.md
+++ b/1.6/ja/book/README.md
@@ -71,7 +71,7 @@ Rustは高級言語のような抽象化も含めた「ゼロコスト抽象化�
 本書を生成するのに使われたソースは以下から入手出来ます
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/rust/tree/master/src/doc/book
+[book]: https://github.com/rust-lang/book/tree/master/first-edition/src
 
 > 訳注: 日本語の翻訳文書は以下から入手出来ます。
 > [GitHub][bookja].

--- a/1.9/ja/book/README.md
+++ b/1.9/ja/book/README.md
@@ -60,7 +60,7 @@ Rustは高級言語のような抽象化も含めた「ゼロコスト抽象化�
 本書を生成するのに使われたソースは以下から入手出来ます
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/rust/tree/master/src/doc/book
+[book]: https://github.com/rust-lang/book/tree/master/first-edition/src
 
 > 訳注: 日本語の翻訳文書は以下から入手出来ます。
 > [GitHub][bookja].


### PR DESCRIPTION
* https://github.com/rust-lang/rust/tree/master/src/doc/book がリンク切れになっていたことから https://github.com/rust-lang/book/tree/master/first-edition/src へ修正