### PR TITLE
Fix closures.md

### DIFF
--- a/1.6/ja/book/closures.md
+++ b/1.6/ja/book/closures.md
@@ -271,7 +271,7 @@ assert_eq!(5, num);
 <!-- objects][trait-objects]. -->
 Rustにおけるクロージャの実装は他の言語とは少し異なります。
 Rustにおけるクロージャは実質的にトレイトへの糖衣構文です。
-続きの説明を読む前に [トレイト][traits] や [トレイトオブジェクト][trait-objects] についてのチャプタを学ぶ前に読みたくなるでしょう。
+続きの説明を読む前に [トレイト][traits] や [トレイトオブジェクト][trait-objects] についてのチャプタを読みたくなるでしょう。
 
 [traits]: traits.html
 [trait-objects]: trait-objects.html

--- a/1.9/ja/book/closures.md
+++ b/1.9/ja/book/closures.md
@@ -271,7 +271,7 @@ assert_eq!(5, num);
 <!-- objects][trait-objects]. -->
 Rustにおけるクロージャの実装は他の言語とは少し異なります。
 Rustにおけるクロージャは実質的にトレイトへの糖衣構文です。
-続きの説明を読む前に [トレイト][traits] や [トレイトオブジェクト][trait-objects] についてのセクションを学ぶ前に読みたくなるでしょう。
+続きの説明を読む前に [トレイト][traits] や [トレイトオブジェクト][trait-objects] についてのセクションを読みたくなるでしょう。
 
 [traits]: traits.html
 [trait-objects]: trait-objects.html


### PR DESCRIPTION
> You’ll want to make sure to have read the traits chapter before this one

の訳として、文頭にすでに

> 続きの説明を読む前に

とあるので、「学ぶ前に」 という記述は不要かと思いました。