### PR TITLE
'one of the only'を「唯一の箇所の一つ」から「数少ない箇所の一つ」に

### DIFF
--- a/1.6/ja/book/deref-coercions.md
+++ b/1.6/ja/book/deref-coercions.md
@@ -65,7 +65,7 @@ foo(&owned);
 <!-- That’s it. This rule is one of the only places in which Rust does an automatic -->
 <!-- conversion for you, but it adds a lot of flexibility. For example, the `Rc<T>` -->
 <!-- type implements `Deref<Target=T>`, so this works: -->
-以上です! このルールはRustが自動的に変換を行う唯一の箇所の一つです。
+以上です! このルールはRustが自動的に変換を行う数少ない箇所の一つです。
 これによって、多くの柔軟性が手にはいります。
 例えば `Rc<T>` は `Deref<Target=T>` を実装しているため、以下のコードは正しく動作します:
 

--- a/1.9/ja/book/deref-coercions.md
+++ b/1.9/ja/book/deref-coercions.md
@@ -65,7 +65,7 @@ foo(&owned);
 <!-- That’s it. This rule is one of the only places in which Rust does an automatic -->
 <!-- conversion for you, but it adds a lot of flexibility. For example, the `Rc<T>` -->
 <!-- type implements `Deref<Target=T>`, so this works: -->
-以上です! このルールはRustが自動的に変換を行う唯一の箇所の一つです。
+以上です! このルールはRustが自動的に変換を行う数少ない箇所の一つです。
 これによって、多くの柔軟性が手にはいります。
 例えば `Rc<T>` は `Deref<Target=T>` を実装しているため、以下のコードは正しく動作します:
 


### PR DESCRIPTION
`one of the only` == `one of very few` != `the only` [(参考)](https://www.merriam-webster.com/dictionary/one%20of%20the%20only)なので、修正しました。
[こちら](https://qiita.com/emonuh/items/2607adfc7e7addd2a571#%E3%81%BE%E3%81%A8%E3%82%81)や[こちら](https://qiita.com/knknkn1162/items/0606ffa17a1aed)など、混乱している方がいるので、結構重要な変更かと思います。。。

よろしくお願いいたします。