### PR TITLE
"more than one" の訳を「1つ以上」から「2つ以上」に修正

### DIFF
--- a/1.6/ja/book/traits.md
+++ b/1.6/ja/book/traits.md
@@ -335,7 +335,7 @@ fn foo<T: Clone>(x: T) {
 ```
 
 <!-- If you need more than one bound, you can use `+`: -->
-1つ以上の境界を与えたい場合、 `+` を使えます。
+2つ以上の境界を与えたい場合、 `+` を使えます。
 
 ```rust
 use std::fmt::Debug;

--- a/1.9/ja/book/traits.md
+++ b/1.9/ja/book/traits.md
@@ -342,7 +342,7 @@ fn foo<T: Clone>(x: T) {
 ```
 
 <!-- If you need more than one bound, you can use `+`: -->
-1つ以上の境界を与えたい場合、 `+` を使えます。
+2つ以上の境界を与えたい場合、 `+` を使えます。
 
 ```rust
 use std::fmt::Debug;


### PR DESCRIPTION
🙏 